### PR TITLE
Align local dev ports

### DIFF
--- a/API_INTEGRATION_GUIDE.md
+++ b/API_INTEGRATION_GUIDE.md
@@ -29,7 +29,7 @@ cp .env.example .env
 Configure your environment variables in `.env`:
 ```env
 # API Configuration
-VITE_API_BASE_URL=http://localhost:3001/api
+VITE_API_BASE_URL=http://localhost:3000/api
 VITE_USE_REAL_API=false
 
 # Individual API endpoint flags
@@ -240,7 +240,7 @@ export const API_TIMEOUT = {
 
 ### Development Setup
 ```env
-VITE_API_BASE_URL=http://localhost:3001/api
+VITE_API_BASE_URL=http://localhost:3000/api
 VITE_USE_REAL_API=false  # Use mock data during development
 ```
 

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -399,7 +399,7 @@ cdk deploy
 **Development**
 ```env
 JWT_SECRET_KEY=dev-secret-key
-CORS_ORIGINS=["http://localhost:3000", "http://localhost:5173"]
+CORS_ORIGINS=["http://localhost:3000", "http://localhost:8080"]
 LOG_LEVEL=DEBUG
 ```
 

--- a/HMS_PATIENTS_API.md
+++ b/HMS_PATIENTS_API.md
@@ -220,7 +220,7 @@ app.use("/api", createProxyMiddleware({
   pathRewrite: { "^/api": "" }
 }));
 
-app.listen(3001, () => console.log("Dev proxy on http://localhost:3001 ->", target));
+app.listen(3000, () => console.log("Dev proxy on http://localhost:3000 ->", target));
 ```
 
 Start the proxy with:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,7 +27,7 @@ app = FastAPI(
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[
-        "http://localhost:5173",  # Vite dev server
+        "http://localhost:8080",  # Vite dev server
         "http://localhost:3000",  # Alternative dev port
         "https://clinical-canvas.com",  # Production domain
         "*"  # Allow all origins for development (remove in production)

--- a/dev-proxy.js
+++ b/dev-proxy.js
@@ -15,7 +15,7 @@ app.use('/api',
   }),
 );
 
-const port = process.env.PORT || 3001;
+const port = process.env.PORT || 3000;
 app.listen(port, () => {
   console.log(`Dev proxy on http://localhost:${port} -> ${target}`);
 });

--- a/runinstructions.md
+++ b/runinstructions.md
@@ -40,7 +40,7 @@ npm install           # installs 496 pkgs, ~30 s on fast net
 ```ts
 define: {
   'process.env': {
-    VITE_API_BASE_URL: JSON.stringify('http://localhost:3001/api'),
+    VITE_API_BASE_URL: JSON.stringify('http://localhost:3000/api'),
     VITE_USE_REAL_API: JSON.stringify('false'),
     /* feature flags … */
   },
@@ -56,7 +56,7 @@ define: {
 2. Add keys:
 
    ```
-   VITE_API_BASE_URL=http://localhost:3001/api
+   VITE_API_BASE_URL=http://localhost:3000/api
    VITE_USE_REAL_API=false
    ```
 
@@ -69,28 +69,28 @@ define: {
 ## 3 Run the Dev Server
 
 ```bash
-npm run dev -- --host 127.0.0.1 --port 5173
+npm run dev -- --host 127.0.0.1 --port 8080
 ```
 
 Output should show:
 
 ```
 VITE v5.x  ready in 200 ms
-➜  Local:   http://127.0.0.1:5173/
-➜  Network: http://<LAN-IP>:5173/
+➜  Local:   http://127.0.0.1:8080/
+➜  Network: http://<LAN-IP>:8080/
 ```
 
 **Verify the bind**
 
 ```bash
-netstat -an | grep 5173   # should show LISTEN
+netstat -an | grep 8080   # should show LISTEN
 ```
 
 ---
 
 ## 4 Open the App
 
-1. Navigate to **`http://127.0.0.1:5173/login`** (root redirects to /login).
+1. Navigate to **`http://127.0.0.1:8080/login`** (root redirects to /login).
 2. Use any demo credential:
    `sarah.wilson@hospital.com / password123` etc.
 3. You should land on the dashboard.
@@ -122,7 +122,7 @@ netstat -an | grep 5173   # should show LISTEN
 | Goal                                        | Command                             |         |
 | ------------------------------------------- | ----------------------------------- | ------- |
 | Kill every Vite / Node proc on current user | \`pkill -f "vite                    | node"\` |
-| Verify nothing else owns the port           | `lsof -i :5173`                     |         |
+| Verify nothing else owns the port           | `lsof -i :8080`                     |         |
 | Change port quickly                         | `npm run dev -- --port 6006`        |         |
 | Watch env vars in build                     | `grep -R "VITE_API_BASE_URL" dist/` |         |
 
@@ -136,7 +136,7 @@ netstat -an | grep 5173   # should show LISTEN
 | **Blank page @ root**                   | Auth redirect → /login                                      | Go straight to `/login`                                                             |
 | **“process is not defined”** in console | Missing `define` shim or used `import.meta.env` incorrectly | Keep `define` block or refactor env usage                                           |
 | CSS not updating                        | Cached Tailwind JIT output                                  | Save the file again or restart dev server                                           |
-| 404 on API calls                        | Backend not running / using mock mode                       | Set `VITE_USE_REAL_API=true` & start backend at 3001, or keep `false` for mock data |
+| 404 on API calls                        | Backend not running / using mock mode                       | Set `VITE_USE_REAL_API=true` & start backend at 3000, or keep `false` for mock data |
 
 ---
 
@@ -144,7 +144,7 @@ netstat -an | grep 5173   # should show LISTEN
 
 ```bash
 # From project root
-pkill -f "vite|node" 2>/dev/null; npm run dev -- --host 127.0.0.1 --port 5173 &
+pkill -f "vite|node" 2>/dev/null; npm run dev -- --host 127.0.0.1 --port 8080 &
 ```
 
 The ampersand (`&`) backgrounds Vite so your terminal stays free for git commands.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,9 +10,8 @@ export default defineConfig(({ mode }) => ({
     port: 8080,
     proxy: {
       "/api": {
-        target: "https://o7ykvdqu5pbnr2fhtuoddbgj3y0peneo.lambda-url.us-east-1.on.aws",
+        target: "http://localhost:3000",
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, ""),
         configure: (proxy, _options) => {
           proxy.on('error', (err, _req, _res) => {
             console.log('Proxy error:', err);


### PR DESCRIPTION
## Summary
- Set dev proxy to default to port 3000
- Configure Vite dev server on 8080 proxying `/api` to the local proxy
- Update docs and backend CORS settings to reflect new port usage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, interface warnings, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6896d95509088333992f0ed48e364967