### PR TITLE
fix: add demographics endpoint and correct patient lookup

### DIFF
--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -12,6 +12,7 @@ export const API_CONFIG = {
     CREATE: "/patients",
     UPDATE: "/patients/:id",
     DELETE: "/patients/:id",
+    DEMOGRAPHICS: "/patients/:id/demographics",
     // QR_DATA temporarily disabled
     TIMELINE: "/patients/:id/timeline",
     ASSIGNMENTS: "/patients/assignments",

--- a/src/services/patientService.ts
+++ b/src/services/patientService.ts
@@ -171,18 +171,18 @@ export const patientService = {
   async getPatientById(mrn: string): Promise<PatientMeta | null> {
     const mockPatient = mockPatients.find((p) => p.id === mrn || p.mrn === mrn) || null;
 
-    return fetchWithFallback(
-      async () => {
-        const { data } = await apiService.get<PatientMeta>(
-          API_CONFIG.PATIENTS.LIST,
-          { mrn }
-        );
-        return { data, success: true };
-      },
-      mockPatient,
-      FEATURE_FLAGS.ENABLE_PATIENTS_API,
-    );
-  },
+      return fetchWithFallback(
+        async () => {
+          const { data } = await apiService.get<PatientMeta>(
+            API_CONFIG.PATIENTS.DETAIL,
+            { id: mrn }
+          );
+          return { data, success: true };
+        },
+        mockPatient,
+        FEATURE_FLAGS.ENABLE_PATIENTS_API,
+      );
+    },
 
   // QR temporarily disabled
   // async getPatientQRData(patientId: string): Promise<unknown> {


### PR DESCRIPTION
## Summary
- add missing patient demographics API endpoint so URLs resolve correctly
- request patient details via `/patients/:id` instead of query param list lookup

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: 62 problems)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898581075408333b50ad77e3477b17c