### PR TITLE
feat: integrate HMS API client

### DIFF
--- a/src/components/patient/AddPatientForm.tsx
+++ b/src/components/patient/AddPatientForm.tsx
@@ -27,6 +27,8 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/hooks/use-toast";
+import api from "@/lib/api";
+import type { Patient } from "@/types/api";
 
 const addPatientSchema = z.object({
   name: z.string().min(2, "Name must be at least 2 characters"),
@@ -51,7 +53,7 @@ type AddPatientFormValues = z.infer<typeof addPatientSchema>;
 interface AddPatientFormProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onAddPatient?: (patient: AddPatientFormValues) => void;
+  onAddPatient?: (patient: Patient) => void;
 }
 
 export function AddPatientForm({ open, onOpenChange, onAddPatient }: AddPatientFormProps) {
@@ -77,19 +79,29 @@ export function AddPatientForm({ open, onOpenChange, onAddPatient }: AddPatientF
 
   const onSubmit = async (data: AddPatientFormValues) => {
     setIsSubmitting(true);
-    
+
     try {
-      // Simulate API call
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
-      // Add patient to the list
-      onAddPatient?.(data);
-      
+      const res = await api.patients.create({
+        mrn: data.mrn,
+        name: data.name,
+        department: "General",
+        age: parseInt(data.age, 10),
+        sex: data.gender,
+        pathway: data.pathway,
+        diagnosis: data.diagnosis,
+        comorbidities: data.comorbidities
+          ? data.comorbidities.split(",").map((c) => c.trim())
+          : [],
+        assignedDoctorId: data.assignedDoctor,
+      });
+
+      onAddPatient?.(res.patient);
+
       toast({
         title: "Patient added successfully",
         description: `${data.name} has been added to the system.`,
       });
-      
+
       form.reset();
       onOpenChange(false);
     } catch (error) {

--- a/src/components/patient/PatientCard.tsx
+++ b/src/components/patient/PatientCard.tsx
@@ -4,11 +4,11 @@ import { Badge } from "@/components/ui/badge";
 import { StageChip } from "./StageChip";
 import { UpdateRing } from "./UpdateRing";
 import { QRCodeGenerator } from "@/components/qr/QRCodeGenerator";
-import { PatientMeta } from "@/types/models";
+import type { Patient } from "@/types/api";
 import { Calendar, MapPin, Clock, QrCode } from "lucide-react";
 
 interface PatientCardProps {
-  patient: PatientMeta;
+  patient: Patient;
   onClick?: () => void;
 }
 

--- a/src/components/patient/PatientCard.tsx
+++ b/src/components/patient/PatientCard.tsx
@@ -99,7 +99,7 @@ export function PatientCard({ patient, onClick }: PatientCardProps) {
           </div>
 
           {/* Comorbidities */}
-          {patient.comorbidities.length > 0 && (
+          {patient.comorbidities && patient.comorbidities.length > 0 && (
             <div className="flex flex-wrap gap-1 mt-2">
               {patient.comorbidities.slice(0, 3).map((comorbidity) => (
                 <Badge key={comorbidity} variant="secondary" className="text-xs">

--- a/src/components/patient/Timeline.tsx
+++ b/src/components/patient/Timeline.tsx
@@ -1,7 +1,7 @@
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { CheckCircle, Circle, Clock } from "lucide-react";
-import { TimelineEntry } from "@/types/models";
+import { TimelineEntry } from "@/types/api";
 import { cn } from "@/lib/utils";
 
 interface TimelineProps {

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Patient, Task, Note, Medication, Doctor } from '@/types/api';
+import type { Patient, Task, Note, Medication, Doctor, TimelineEntry } from '@/types/api';
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
 
@@ -28,6 +28,7 @@ export const api = {
     list: (department?: string) =>
       request<Patient[]>(`/patients${department ? `?department=${encodeURIComponent(department)}` : ''}`),
     get: (mrn: string) => request<Patient>(`/patients/${mrn}`),
+    timeline: (mrn: string) => request<TimelineEntry[]>(`/patients/${mrn}/timeline`),
     create: (data: Omit<Patient, 'id' | 'lastUpdated' | 'status'> & { mrn: string; name: string; department: string }) =>
       request<{ message: string; mrn: string; patient: Patient }>(`/patients`, {
         method: 'POST',

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,147 @@
+import type { Patient, Task, Note, Medication, Doctor } from '@/types/api';
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
+
+function toSnakeCase(obj: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    const snake = key.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`);
+    result[snake] = value as unknown;
+  }
+  return result;
+}
+
+async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+    ...options,
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.error || res.statusText);
+  }
+  return res.json();
+}
+
+export const api = {
+  patients: {
+    list: (department?: string) =>
+      request<Patient[]>(`/patients${department ? `?department=${encodeURIComponent(department)}` : ''}`),
+    get: (mrn: string) => request<Patient>(`/patients/${mrn}`),
+    create: (data: Omit<Patient, 'id' | 'lastUpdated' | 'status'> & { mrn: string; name: string; department: string }) =>
+      request<{ message: string; mrn: string; patient: Patient }>(`/patients`, {
+        method: 'POST',
+        body: JSON.stringify(toSnakeCase(data)),
+      }),
+    update: (mrn: string, data: Partial<Patient>) =>
+      request<{ message: string; mrn: string; patient: Patient }>(`/patients/${mrn}`, {
+        method: 'PUT',
+        body: JSON.stringify(toSnakeCase(data as Record<string, unknown>)),
+      }),
+    remove: (mrn: string) =>
+      request<{ message: string; mrn: string; patient: Patient }>(`/patients/${mrn}`, {
+        method: 'DELETE',
+      }),
+  },
+  tasks: {
+    list: (mrn: string, status?: string, limit?: number) => {
+      const params = new URLSearchParams();
+      if (status) params.append('status', status);
+      if (limit) params.append('limit', String(limit));
+      const query = params.size ? `?${params.toString()}` : '';
+      return request<Task[]>(`/patients/${mrn}/tasks${query}`);
+    },
+    create: (mrn: string, data: Omit<Task, 'taskId' | 'createdAt' | 'updatedAt'>) =>
+      request<{ message: string; task: Task }>(`/patients/${mrn}/tasks`, {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }),
+    update: (mrn: string, taskId: string, data: Partial<Task>) =>
+      request<{ message: string; task: Task }>(`/patients/${mrn}/tasks/${taskId}`, {
+        method: 'PATCH',
+        body: JSON.stringify(data),
+      }),
+    remove: (mrn: string, taskId: string) =>
+      request<{ message: string }>(`/patients/${mrn}/tasks/${taskId}`, {
+        method: 'DELETE',
+      }),
+    listByDepartment: (department: string, status = 'open', assigneeId?: string, limit?: number) => {
+      const params = new URLSearchParams({ department, status });
+      if (assigneeId) params.append('assigneeId', assigneeId);
+      if (limit) params.append('limit', String(limit));
+      return request<Task[]>(`/tasks?${params.toString()}`);
+    },
+  },
+  notes: {
+    list: (mrn: string, limit?: number, cursor?: string, includeDeleted?: boolean) => {
+      const params = new URLSearchParams();
+      if (limit) params.append('limit', String(limit));
+      if (cursor) params.append('cursor', cursor);
+      if (includeDeleted) params.append('includeDeleted', includeDeleted ? '1' : '0');
+      const query = params.size ? `?${params.toString()}` : '';
+      return request<{ items: Note[]; nextCursor: string | null }>(`/patients/${mrn}/notes${query}`);
+    },
+    create: (mrn: string, data: Omit<Note, 'noteId' | 'createdAt' | 'updatedAt' | 'deleted'>) =>
+      request<{ message: string; note: Note }>(`/patients/${mrn}/notes`, {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }),
+    update: (mrn: string, noteId: string, data: Partial<Note>) =>
+      request<{ message: string; note: Note }>(`/patients/${mrn}/notes/${noteId}`, {
+        method: 'PATCH',
+        body: JSON.stringify(data),
+      }),
+    remove: (mrn: string, noteId: string) =>
+      request<{ message: string }>(`/patients/${mrn}/notes/${noteId}`, {
+        method: 'DELETE',
+      }),
+  },
+  meds: {
+    list: (mrn: string, active?: boolean, limit?: number, cursor?: string) => {
+      const params = new URLSearchParams();
+      if (active !== undefined) params.append('active', active ? '1' : '0');
+      if (limit) params.append('limit', String(limit));
+      if (cursor) params.append('cursor', cursor);
+      const query = params.size ? `?${params.toString()}` : '';
+      return request<{ items: Medication[]; nextCursor: string | null }>(`/patients/${mrn}/meds${query}`);
+    },
+    create: (mrn: string, data: Omit<Medication, 'medId' | 'createdAt' | 'updatedAt'>) =>
+      request<{ message: string; med: Medication }>(`/patients/${mrn}/meds`, {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }),
+    update: (mrn: string, medId: string, data: Partial<Medication>) =>
+      request<{ message: string; med: Medication }>(`/patients/${mrn}/meds/${medId}`, {
+        method: 'PATCH',
+        body: JSON.stringify(data),
+      }),
+    remove: (mrn: string, medId: string) =>
+      request<{ message: string; med: Medication }>(`/patients/${mrn}/meds/${medId}`, {
+        method: 'DELETE',
+      }),
+  },
+  doctors: {
+    list: (department: string, limit?: number) => {
+      const params = new URLSearchParams({ department });
+      if (limit) params.append('limit', String(limit));
+      return request<Doctor[]>(`/doctors?${params.toString()}`);
+    },
+    get: (doctorId: string) => request<Doctor>(`/doctors/${doctorId}`),
+    create: (data: Omit<Doctor, 'doctorId' | 'createdAt' | 'updatedAt'>) =>
+      request<{ message: string; doctor: Doctor }>(`/doctors`, {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }),
+    update: (doctorId: string, data: Partial<Doctor>) =>
+      request<{ message: string; doctor: Doctor }>(`/doctors/${doctorId}`, {
+        method: 'PATCH',
+        body: JSON.stringify(data),
+      }),
+    remove: (doctorId: string) =>
+      request<{ message: string }>(`/doctors/${doctorId}`, {
+        method: 'DELETE',
+      }),
+  },
+};
+
+export default api;

--- a/src/pages/PatientDetail.tsx
+++ b/src/pages/PatientDetail.tsx
@@ -9,131 +9,17 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { StageChip } from "@/components/patient/StageChip";
 import { Timeline } from "@/components/patient/Timeline";
 import { PatientTasks } from "@/components/patient/PatientTasks";
-import { QrCode, Copy, Phone, Mail, Calendar, MapPin, Clock } from "lucide-react";
-import { PatientMeta, TimelineEntry } from "@/types/models";
-
-// Mock data - replace with real API calls
-const mockPatients: PatientMeta[] = [
-  {
-    id: '27e8d1ad',
-    name: 'Jane Doe',
-    qrCode: 'https://qrc.c/27e8d1ad',
-    pathway: 'surgical',
-    currentState: 'post-op',
-    diagnosis: 'Cholecystitis',
-    comorbidities: ['HTN', 'DM'],
-    updateCounter: 5,
-    lastUpdated: '2025-07-19T14:30:09Z',
-    assignedDoctor: 'Dr. Smith'
-  },
-  {
-    id: '3b9f2c1e',
-    name: 'John Smith',
-    qrCode: 'https://qrc.c/3b9f2c1e',
-    pathway: 'emergency',
-    currentState: 'ICU',
-    diagnosis: 'Acute MI',
-    comorbidities: ['CAD', 'HTN'],
-    updateCounter: 12,
-    lastUpdated: '2025-07-19T16:45:22Z',
-    assignedDoctor: 'Dr. Johnson'
-  },
-  {
-    id: '8c4d5e2f',
-    name: 'Maria Garcia',
-    qrCode: 'https://qrc.c/8c4d5e2f',
-    pathway: 'consultation',
-    currentState: 'stable',
-    diagnosis: 'Osteoarthritis',
-    comorbidities: ['Obesity'],
-    updateCounter: 2,
-    lastUpdated: '2025-07-19T11:20:15Z',
-    assignedDoctor: 'Dr. Smith'
-  },
-  {
-    id: '9d6e7f3g',
-    name: 'Robert Wilson',
-    qrCode: 'https://qrc.c/9d6e7f3g',
-    pathway: 'surgical',
-    currentState: 'pre-op',
-    diagnosis: 'Appendicitis',
-    comorbidities: [],
-    updateCounter: 8,
-    lastUpdated: '2025-07-19T13:15:30Z',
-    assignedDoctor: 'Dr. Smith'
-  },
-  {
-    id: '1a2b3c4d',
-    name: 'Sarah Johnson',
-    qrCode: 'https://qrc.c/1a2b3c4d',
-    pathway: 'emergency',
-    currentState: 'recovery',
-    diagnosis: 'Pneumonia',
-    comorbidities: ['COPD', 'HTN'],
-    updateCounter: 3,
-    lastUpdated: '2025-07-19T09:45:18Z',
-    assignedDoctor: 'Dr. Johnson'
-  }
-];
-
-const mockTimelines: Record<string, TimelineEntry[]> = {
-  '27e8d1ad': [
-    {
-      patientId: '27e8d1ad',
-      state: 'Admission',
-      dateIn: '2025-07-18T08:00:00Z',
-      dateOut: '2025-07-18T10:00:00Z',
-      checklistIn: ['vitals-recorded', 'allergies-checked'],
-      checklistOut: ['pre-op-clearance']
-    },
-    {
-      patientId: '27e8d1ad',
-      state: 'Pre-Op',
-      dateIn: '2025-07-18T10:00:00Z',
-      dateOut: '2025-07-18T14:00:00Z',
-      checklistIn: ['consent-signed', 'fasting-confirmed'],
-      checklistOut: ['anesthesia-cleared']
-    },
-    {
-      patientId: '27e8d1ad',
-      state: 'Surgery',
-      dateIn: '2025-07-18T14:00:00Z',
-      dateOut: '2025-07-18T16:30:00Z',
-      checklistIn: ['timeout-completed', 'antibiotics-given'],
-      checklistOut: ['procedure-completed', 'counts-correct']
-    },
-    {
-      patientId: '27e8d1ad',
-      state: 'Post-Op',
-      dateIn: '2025-07-18T16:30:00Z',
-      checklistIn: ['recovery-stable', 'pain-managed'],
-      checklistOut: []
-    }
-  ],
-  '3b9f2c1e': [
-    {
-      patientId: '3b9f2c1e',
-      state: 'Emergency',
-      dateIn: '2025-07-19T12:00:00Z',
-      dateOut: '2025-07-19T14:00:00Z',
-      checklistIn: ['triage-completed', 'vitals-stable'],
-      checklistOut: ['ecg-completed']
-    },
-    {
-      patientId: '3b9f2c1e',
-      state: 'ICU',
-      dateIn: '2025-07-19T14:00:00Z',
-      checklistIn: ['monitoring-active', 'medications-administered'],
-      checklistOut: []
-    }
-  ]
-};
+import { QrCode, Copy, Phone, Mail, Calendar } from "lucide-react";
+import api from "@/lib/api";
+import type { Patient, TimelineEntry } from "@/types/api";
 
 export default function PatientDetail() {
   const { id } = useParams();
   const navigate = useNavigate();
-  const [activeTab, setActiveTab] = useState('overview');
+  const [activeTab, setActiveTab] = useState("overview");
   const [isScrolled, setIsScrolled] = useState(false);
+  const [patient, setPatient] = useState<Patient | null>(null);
+  const [timeline, setTimeline] = useState<TimelineEntry[]>([]);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -141,164 +27,98 @@ export default function PatientDetail() {
       setIsScrolled(scrollTop > 100);
     };
 
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
-  // Find the current patient based on ID
-  const currentPatient = mockPatients.find(patient => patient.id === id);
-  
-  // If patient not found, redirect to patients list
-  if (!currentPatient) {
-    navigate('/patients');
-    return null;
+  useEffect(() => {
+    if (!id) return;
+    api.patients
+      .get(id)
+      .then((data) => {
+        setPatient(data);
+        return api.patients.timeline(id);
+      })
+      .then(setTimeline)
+      .catch(() => navigate("/patients"));
+  }, [id, navigate]);
+
+  if (!patient) {
+    return (
+      <div className="min-h-screen bg-background pb-20 overflow-x-hidden">
+        <Header
+          title="Patient Details"
+          showBack
+          onBack={() => navigate("/patients")}
+          notificationCount={2}
+        />
+        <div className="p-4 text-sm text-muted-foreground">Loading...</div>
+        <BottomBar />
+      </div>
+    );
   }
-
-  // Get timeline data for current patient
-  const patientTimeline = mockTimelines[currentPatient.id] || [];
-  
-  // Patient-specific demographics data
-  const patientDemographics = {
-    '27e8d1ad': {
-      mrn: 'MRN123456',
-      dob: '1975-03-15',
-      age: 49,
-      gender: 'Female',
-      room: 'Room 204B',
-      admissionDate: '2025-07-18',
-      lengthOfStay: 3,
-      nextMilestone: 'Discharge Planning',
-      nextMilestoneTime: 'Expected tomorrow',
-      allergies: ['Penicillin', 'Latex'],
-      emergencyContact: {
-        name: 'John Doe (Spouse)',
-        phone: '+1-555-0123'
-      }
-    },
-    '3b9f2c1e': {
-      mrn: 'MRN789012',
-      dob: '1980-08-22',
-      age: 44,
-      gender: 'Male', 
-      room: 'ICU Room 12',
-      admissionDate: '2025-07-19',
-      lengthOfStay: 1,
-      nextMilestone: 'Cardiology Consult',
-      nextMilestoneTime: 'This afternoon',
-      allergies: ['Aspirin'],
-      emergencyContact: {
-        name: 'Mary Smith (Wife)',
-        phone: '+1-555-0456'
-      }
-    },
-    '8c4d5e2f': {
-      mrn: 'MRN345678',
-      dob: '1965-12-05',
-      age: 59,
-      gender: 'Female',
-      room: 'Room 108A',
-      admissionDate: '2025-07-19',
-      lengthOfStay: 1,
-      nextMilestone: 'Physical Therapy Evaluation',
-      nextMilestoneTime: 'Next week',
-      allergies: [],
-      emergencyContact: null
-    },
-    '9d6e7f3g': {
-      mrn: 'MRN901234',
-      dob: '1990-05-18',
-      age: 34,
-      gender: 'Male',
-      room: 'Room 315C',
-      admissionDate: '2025-07-19',
-      lengthOfStay: 1,
-      nextMilestone: 'Surgery Scheduled',
-      nextMilestoneTime: 'Tomorrow morning',
-      allergies: ['Morphine'],
-      emergencyContact: {
-        name: 'Linda Wilson (Mother)',
-        phone: '+1-555-0789'
-      }
-    },
-    '1a2b3c4d': {
-      mrn: 'MRN567890',
-      dob: '1978-11-30',
-      age: 46,
-      gender: 'Female',
-      room: 'Room 220B',
-      admissionDate: '2025-07-19',
-      lengthOfStay: 1,
-      nextMilestone: 'Respiratory Assessment',
-      nextMilestoneTime: 'Later today',
-      allergies: ['Codeine'],
-      emergencyContact: {
-        name: 'Michael Johnson (Husband)',
-        phone: '+1-555-0321'
-      }
-    }
-  };
-
-  const demographics = patientDemographics[currentPatient.id];
 
   return (
     <div className="min-h-screen bg-background pb-20 overflow-x-hidden">
-      <Header 
-        title="Patient Details" 
+      <Header
+        title="Patient Details"
         showBack
-        onBack={() => navigate('/patients')}
+        onBack={() => navigate("/patients")}
         notificationCount={2}
       />
-      
-      {/* Sticky Header on Scroll */}
+
       {isScrolled && (
         <div className="fixed top-16 left-0 right-0 z-40 bg-background/95 backdrop-blur-sm border-b shadow-sm">
           <div className="px-3 sm:px-4 lg:px-6 py-2">
             <div className="flex items-center justify-between">
               <div className="min-w-0 flex-1">
                 <h2 className="text-sm sm:text-base font-semibold text-foreground truncate">
-                  {currentPatient.name}
+                  {patient.name}
                 </h2>
                 <p className="text-xs text-muted-foreground truncate">
-                  {demographics?.mrn} • {currentPatient.currentState}
+                  {patient.mrn} • {patient.currentState}
                 </p>
               </div>
-              <StageChip stage={currentPatient.currentState} variant="caution" size="sm" />
+              <StageChip stage={patient.currentState || ""} variant="caution" size="sm" />
             </div>
           </div>
         </div>
       )}
-      
-      <div className={`p-3 sm:p-4 lg:p-6 space-y-4 sm:space-y-6 ${isScrolled ? 'pt-20' : ''}`}>
-        {/* Patient Hero */}
+
+      <div className={`p-3 sm:p-4 lg:p-6 space-y-4 sm:space-y-6 ${isScrolled ? "pt-20" : ""}`}>
         <Card className="p-4 sm:p-6">
           <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-4">
             <div className="flex-1 min-w-0">
-              <h1 className="text-xl sm:text-2xl font-bold text-foreground mb-3 break-words">{currentPatient.name}</h1>
+              <h1 className="text-xl sm:text-2xl font-bold text-foreground mb-3 break-words">{patient.name}</h1>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4 text-sm">
                 <div className="space-y-2">
                   <div className="flex items-center gap-2 flex-wrap">
                     <span className="text-muted-foreground whitespace-nowrap">MRN:</span>
-                    <span className="font-medium break-all">{demographics?.mrn}</span>
+                    <span className="font-medium break-all">{patient.mrn}</span>
                     <Button variant="ghost" size="sm" className="h-6 w-6 p-0 flex-shrink-0">
                       <Copy className="h-3 w-3" />
                     </Button>
                   </div>
-                  <div className="flex items-center gap-2">
-                    <Calendar className="h-3 w-3 text-muted-foreground flex-shrink-0" />
-                    <span className="whitespace-nowrap">{demographics?.age} years old</span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <MapPin className="h-3 w-3 text-muted-foreground flex-shrink-0" />
-                    <span className="break-words">{demographics?.room}</span>
-                  </div>
+                  {patient.age !== undefined && (
+                    <div className="flex items-center gap-2">
+                      <Calendar className="h-3 w-3 text-muted-foreground flex-shrink-0" />
+                      <span className="whitespace-nowrap">{patient.age} years old</span>
+                    </div>
+                  )}
+                  {patient.sex && (
+                    <div className="flex items-center gap-2">
+                      <span className="text-muted-foreground">Sex:</span>
+                      <span className="break-words capitalize">{patient.sex}</span>
+                    </div>
+                  )}
                 </div>
                 <div className="space-y-2">
                   <div className="text-muted-foreground">Pathway:</div>
                   <Badge variant="outline" className="capitalize w-fit">
-                    {currentPatient.pathway}
+                    {patient.pathway}
                   </Badge>
                   <div className="text-muted-foreground">Current Stage:</div>
-                  <StageChip stage={currentPatient.currentState} variant="caution" />
+                  <StageChip stage={patient.currentState || ""} variant="caution" />
                 </div>
               </div>
             </div>
@@ -308,18 +128,17 @@ export default function PatientDetail() {
             </Button>
           </div>
 
-          {/* Diagnosis and Comorbidities */}
           <div className="space-y-3 sm:space-y-4">
             <div>
               <span className="text-sm text-muted-foreground">Primary Diagnosis:</span>
-              <div className="font-medium mt-1 break-words">{currentPatient.diagnosis}</div>
+              <div className="font-medium mt-1 break-words">{patient.diagnosis}</div>
             </div>
-            
-            {currentPatient.comorbidities.length > 0 && (
+
+            {patient.comorbidities && patient.comorbidities.length > 0 && (
               <div>
                 <span className="text-sm text-muted-foreground">Comorbidities:</span>
                 <div className="flex flex-wrap gap-1.5 sm:gap-2 mt-2">
-                  {currentPatient.comorbidities.map((comorbidity) => (
+                  {patient.comorbidities.map((comorbidity) => (
                     <Badge key={comorbidity} variant="secondary" className="text-xs">
                       {comorbidity}
                     </Badge>
@@ -328,70 +147,58 @@ export default function PatientDetail() {
               </div>
             )}
 
-            {demographics?.allergies && demographics.allergies.length > 0 && (
-              <div>
-                <span className="text-sm text-muted-foreground">Allergies:</span>
-                <div className="flex flex-wrap gap-1.5 sm:gap-2 mt-2">
-                  {demographics.allergies.map((allergy) => (
-                    <Badge key={allergy} variant="destructive" className="text-xs">
-                      {allergy}
-                    </Badge>
-                  ))}
+            {patient.emergencyContact && (
+              <div className="mt-4 sm:mt-6 pt-4 border-t">
+                <span className="text-sm text-muted-foreground">Emergency Contact:</span>
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mt-2">
+                  <span className="font-medium break-words">
+                    {patient.emergencyContact.name}
+                    {patient.emergencyContact.relationship ? ` (${patient.emergencyContact.relationship})` : ""}
+                  </span>
+                  <div className="flex flex-col sm:flex-row gap-2">
+                    <Button variant="outline" size="sm" className="w-full sm:w-auto">
+                      <Phone className="h-3 w-3 mr-1" />
+                      Call
+                    </Button>
+                    <Button variant="outline" size="sm" className="w-full sm:w-auto">
+                      <Mail className="h-3 w-3 mr-1" />
+                      Email
+                    </Button>
+                  </div>
                 </div>
               </div>
             )}
           </div>
-
-          {/* Emergency Contact */}
-          {demographics?.emergencyContact && (
-            <div className="mt-4 sm:mt-6 pt-4 border-t">
-              <span className="text-sm text-muted-foreground">Emergency Contact:</span>
-              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mt-2">
-                <span className="font-medium break-words">{demographics.emergencyContact.name}</span>
-                <div className="flex flex-col sm:flex-row gap-2">
-                  <Button variant="outline" size="sm" className="w-full sm:w-auto">
-                    <Phone className="h-3 w-3 mr-1" />
-                    Call
-                  </Button>
-                  <Button variant="outline" size="sm" className="w-full sm:w-auto">
-                    <Mail className="h-3 w-3 mr-1" />
-                    Email
-                  </Button>
-                </div>
-              </div>
-            </div>
-          )}
         </Card>
 
-        {/* Tabs Navigation */}
         <Tabs value={activeTab} onValueChange={setActiveTab}>
           <TabsList className="grid w-full grid-cols-5 h-auto p-1 bg-muted/50 rounded-lg border">
-            <TabsTrigger 
-              value="overview" 
+            <TabsTrigger
+              value="overview"
               className="text-xs sm:text-sm px-2 sm:px-3 py-2 data-[state=active]:bg-background data-[state=active]:shadow-sm rounded-md transition-all"
             >
               Overview
             </TabsTrigger>
-            <TabsTrigger 
-              value="notes" 
+            <TabsTrigger
+              value="notes"
               className="text-xs sm:text-sm px-2 sm:px-3 py-2 data-[state=active]:bg-background data-[state=active]:shadow-sm rounded-md transition-all"
             >
               Notes
             </TabsTrigger>
-            <TabsTrigger 
-              value="labs" 
+            <TabsTrigger
+              value="labs"
               className="text-xs sm:text-sm px-2 sm:px-3 py-2 data-[state=active]:bg-background data-[state=active]:shadow-sm rounded-md transition-all"
             >
               Labs
             </TabsTrigger>
-            <TabsTrigger 
-              value="meds" 
+            <TabsTrigger
+              value="meds"
               className="text-xs sm:text-sm px-2 sm:px-3 py-2 data-[state=active]:bg-background data-[state=active]:shadow-sm rounded-md transition-all"
             >
               Meds
             </TabsTrigger>
-            <TabsTrigger 
-              value="tasks" 
+            <TabsTrigger
+              value="tasks"
               className="text-xs sm:text-sm px-2 sm:px-3 py-2 data-[state=active]:bg-background data-[state=active]:shadow-sm rounded-md transition-all"
             >
               Tasks
@@ -400,70 +207,34 @@ export default function PatientDetail() {
 
           <TabsContent value="overview" className="space-y-4 mt-6">
             <div className="space-y-4">
-              {/* Patient Information Summary */}
               <Card className="p-4 sm:p-6 border-l-4 border-l-primary">
                 <h3 className="font-semibold mb-3 text-base sm:text-lg">Patient Overview</h3>
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 text-sm">
                   <div>
                     <span className="text-muted-foreground">Diagnosis:</span>
-                    <p className="font-medium mt-1">{currentPatient.diagnosis}</p>
+                    <p className="font-medium mt-1">{patient.diagnosis}</p>
                   </div>
-                  <div>
-                    <span className="text-muted-foreground">Assigned Doctor:</span>
-                    <p className="font-medium mt-1">{currentPatient.assignedDoctor}</p>
-                  </div>
-                  <div>
-                    <span className="text-muted-foreground">Last Updated:</span>
-                    <p className="font-medium mt-1">{new Date(currentPatient.lastUpdated).toLocaleDateString()}</p>
-                  </div>
-                </div>
-                
-                {/* Allergies in Overview */}
-                {demographics?.allergies && demographics.allergies.length > 0 && (
-                  <div className="mt-4 pt-4 border-t">
-                    <span className="text-sm text-muted-foreground font-medium">⚠️ Allergies:</span>
-                    <div className="flex flex-wrap gap-2 mt-2">
-                      {demographics.allergies.map((allergy) => (
-                        <Badge key={allergy} variant="destructive" className="text-xs">
-                          {allergy}
-                        </Badge>
-                      ))}
+                  {patient.assignedDoctor && (
+                    <div>
+                      <span className="text-muted-foreground">Assigned Doctor:</span>
+                      <p className="font-medium mt-1">{patient.assignedDoctor}</p>
                     </div>
-                  </div>
-                )}
+                  )}
+                  {patient.lastUpdated && (
+                    <div>
+                      <span className="text-muted-foreground">Last Updated:</span>
+                      <p className="font-medium mt-1">{new Date(patient.lastUpdated).toLocaleDateString()}</p>
+                    </div>
+                  )}
+                </div>
               </Card>
 
-              {/* Timeline */}
-              {patientTimeline.length > 0 ? (
-                <Timeline entries={patientTimeline} currentState={currentPatient.currentState} />
+              {timeline.length > 0 ? (
+                <Timeline entries={timeline} currentState={patient.currentState || ""} />
               ) : (
                 <Card className="p-4 sm:p-6">
                   <p className="text-muted-foreground text-center text-sm sm:text-base">No timeline data available for this patient</p>
                 </Card>
-              )}
-              
-              {/* Quick Stats */}
-              {demographics && (
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                  <Card className="p-4 sm:p-6 border border-border/50">
-                    <h3 className="font-semibold mb-3 text-sm sm:text-base flex items-center gap-2">
-                      <Calendar className="h-4 w-4 text-primary" />
-                      Length of Stay
-                    </h3>
-                    <p className="text-2xl sm:text-3xl font-bold text-primary mb-1">
-                      {demographics.lengthOfStay} {demographics.lengthOfStay === 1 ? 'day' : 'days'}
-                    </p>
-                    <p className="text-xs sm:text-sm text-muted-foreground">Since admission on {new Date(demographics.admissionDate).toLocaleDateString()}</p>
-                  </Card>
-                  <Card className="p-4 sm:p-6 border border-border/50">
-                    <h3 className="font-semibold mb-3 text-sm sm:text-base flex items-center gap-2">
-                      <Clock className="h-4 w-4 text-primary" />
-                      Next Milestone
-                    </h3>
-                    <p className="text-base sm:text-lg font-medium mb-1 break-words">{demographics.nextMilestone}</p>
-                    <p className="text-xs sm:text-sm text-muted-foreground">{demographics.nextMilestoneTime}</p>
-                  </Card>
-                </div>
               )}
             </div>
           </TabsContent>
@@ -475,7 +246,7 @@ export default function PatientDetail() {
                 <div className="space-y-3">
                   <div className="text-sm text-muted-foreground bg-muted/30 p-3 rounded-lg border border-dashed">
                     <p className="text-center py-8">Clinical notes will be displayed here</p>
-                    <p className="text-center text-xs">Patient: {currentPatient.name} • ID: {currentPatient.id}</p>
+                    <p className="text-center text-xs">Patient: {patient.name} • ID: {patient.mrn}</p>
                   </div>
                 </div>
               </div>
@@ -489,7 +260,7 @@ export default function PatientDetail() {
                 <div className="space-y-3">
                   <div className="text-sm text-muted-foreground bg-muted/30 p-3 rounded-lg border border-dashed">
                     <p className="text-center py-8">Lab results will be displayed here</p>
-                    <p className="text-center text-xs">Patient: {currentPatient.name} • ID: {currentPatient.id}</p>
+                    <p className="text-center text-xs">Patient: {patient.name} • ID: {patient.mrn}</p>
                   </div>
                 </div>
               </div>
@@ -503,7 +274,7 @@ export default function PatientDetail() {
                 <div className="space-y-3">
                   <div className="text-sm text-muted-foreground bg-muted/30 p-3 rounded-lg border border-dashed">
                     <p className="text-center py-8">Medication list will be displayed here</p>
-                    <p className="text-center text-xs">Patient: {currentPatient.name} • ID: {currentPatient.id}</p>
+                    <p className="text-center text-xs">Patient: {patient.name} • ID: {patient.mrn}</p>
                   </div>
                 </div>
               </div>
@@ -514,7 +285,7 @@ export default function PatientDetail() {
             <Card className="p-4 sm:p-6 min-h-[400px] border border-border/50">
               <div className="space-y-4">
                 <h3 className="font-semibold text-base sm:text-lg">Patient Tasks</h3>
-                <PatientTasks patientId={currentPatient.id} />
+                <PatientTasks patientId={patient.mrn} />
               </div>
             </Card>
           </TabsContent>

--- a/src/pages/PatientQRView.tsx
+++ b/src/pages/PatientQRView.tsx
@@ -36,11 +36,13 @@ const mockPatientData = {
       { time: '08:30', note: 'Patient awake and responsive', type: 'observation' }
     ]
   }
-};
+} as const;
+
+type MockPatient = (typeof mockPatientData)[keyof typeof mockPatientData];
 
 export default function PatientQRView() {
   const { id } = useParams<{ id: string }>();
-  const [patient, setPatient] = useState<any>(null);
+  const [patient, setPatient] = useState<MockPatient | null>(null);
   const [lastUpdate, setLastUpdate] = useState<string>('');
 
   useEffect(() => {
@@ -190,7 +192,8 @@ export default function PatientQRView() {
           </CardHeader>
           <CardContent className="pt-0">
             <div className="space-y-3">
-              {patient.recentUpdates.map((update: any, index: number) => (
+              {patient.recentUpdates.map(
+                (update: MockPatient['recentUpdates'][number], index: number) => (
                 <div key={index} className="flex items-start gap-3 pb-3 border-b last:border-b-0 last:pb-0">
                   <div className="flex items-center gap-2 min-w-0">
                     <Clock className="h-3 w-3 text-muted-foreground flex-shrink-0" />
@@ -203,7 +206,8 @@ export default function PatientQRView() {
                     </Badge>
                   </div>
                 </div>
-              ))}
+              )
+              )}
             </div>
           </CardContent>
         </Card>

--- a/src/pages/PatientsList.tsx
+++ b/src/pages/PatientsList.tsx
@@ -37,6 +37,7 @@ export default function PatientsList() {
           id: p.id || p.mrn,
           qrCode: `${window.location.origin}/qr/${p.mrn}`,
           updateCounter: 0,
+          comorbidities: p.comorbidities || [],
         }));
         setPatients(withUi);
         mockPatients = withUi;
@@ -68,6 +69,7 @@ export default function PatientsList() {
       id: patient.id || patient.mrn,
       qrCode: `${window.location.origin}/qr/${patient.mrn}`,
       updateCounter: 0,
+      comorbidities: patient.comorbidities || [],
     };
     setPatients((prev) => [...prev, withUi]);
     mockPatients = [...mockPatients, withUi];

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -11,8 +11,17 @@ export interface Patient {
   diagnosis?: string;
   age?: number;
   sex?: string;
-  comorbidities: string[];
+  comorbidities?: string[];
+  assignedDoctor?: string;
   assignedDoctorId?: string;
+  isUrgent?: boolean;
+  urgentReason?: string;
+  urgentUntil?: string;
+  emergencyContact?: {
+    name: string;
+    relationship?: string;
+    phone?: string;
+  };
   filesUrl?: string | null;
   lastUpdated?: string;
   // UI-specific optional fields
@@ -76,6 +85,22 @@ export interface Doctor {
   contactInfo: Record<string, string>;
   permissions: string[];
   email: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TimelineEntry {
+  timelineId: string;
+  patientId: string;
+  state: string;
+  dateIn: string;
+  dateOut?: string | null;
+  requiredIn: string[];
+  requiredOut: string[];
+  checklistIn: string[];
+  checklistOut: string[];
+  actorId?: string;
+  notes?: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,81 @@
+// API models based on HMS API spec
+
+export interface Patient {
+  id: string; // = mrn
+  mrn: string;
+  name: string;
+  department: string;
+  status: 'ACTIVE' | 'INACTIVE';
+  pathway?: 'surgical' | 'consultation' | 'emergency';
+  currentState?: string;
+  diagnosis?: string;
+  age?: number;
+  sex?: string;
+  comorbidities: string[];
+  assignedDoctorId?: string;
+  filesUrl?: string | null;
+  lastUpdated?: string;
+  // UI-specific optional fields
+  qrCode?: string;
+  updateCounter?: number;
+}
+
+export interface Task {
+  taskId: string;
+  patientId: string;
+  title: string;
+  type: 'lab' | 'medication' | 'procedure' | 'assessment' | 'discharge';
+  due: string;
+  assigneeId: string;
+  status: 'open' | 'in-progress' | 'done' | 'cancelled';
+  priority: 'low' | 'medium' | 'high' | 'urgent';
+  recurring: boolean;
+  recurrence?: {
+    frequency: string;
+    until?: string;
+    daysOfWeek?: string[];
+  } | null;
+  details?: Record<string, unknown> | null;
+  department?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Note {
+  noteId: string;
+  patientId: string;
+  authorId: string;
+  category: 'doctorNote' | 'nurseNote' | 'pharmacy' | 'discharge';
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+  deleted: boolean;
+}
+
+export interface Medication {
+  medId: string;
+  patientId: string;
+  name: string;
+  dose: string;
+  route: string;
+  freq: string;
+  start: string;
+  end?: string | null;
+  priority: 'routine' | 'important' | 'critical';
+  scheduleTimes: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Doctor {
+  doctorId: string;
+  name: string;
+  role: string;
+  department?: string | null;
+  avatar?: string | null;
+  contactInfo: Record<string, string>;
+  permissions: string[];
+  email: string;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -13,15 +13,6 @@ export interface PatientMeta {
   assignedDoctor?: string;
 }
 
-export interface TimelineEntry {
-  patientId: string;
-  state: string;
-  dateIn: string;
-  dateOut?: string;
-  checklistIn: string[];
-  checklistOut: string[];
-}
-
 export interface Task {
   taskId: string;
   patientId: string;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -133,5 +134,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- define HMS API TypeScript models
- add API client for patients, tasks, notes, meds, doctors
- load patients from API instead of mock data
- create patients via API using snake_case payloads

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68996c14a3a483338be6e20cef1f447c