### PR TITLE
feat: display patient notes and meds

### DIFF
--- a/src/components/patient/PatientMeds.tsx
+++ b/src/components/patient/PatientMeds.tsx
@@ -1,0 +1,57 @@
+import { useState, useEffect } from "react";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import type { Medication } from "@/types/api";
+import api from "@/lib/api";
+
+interface PatientMedsProps {
+  patientId: string;
+}
+
+export function PatientMeds({ patientId }: PatientMedsProps) {
+  const [meds, setMeds] = useState<Medication[]>([]);
+
+  useEffect(() => {
+    api.meds
+      .list(patientId, true, 50)
+      .then((res) => setMeds(res.items))
+      .catch((err) => console.error(err));
+  }, [patientId]);
+
+  if (meds.length === 0) {
+    return (
+      <div className="text-center py-6 text-muted-foreground text-sm bg-muted/30 rounded-lg border border-dashed">
+        No medications for this patient
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {meds.map((med) => (
+        <Card key={med.medId} className="p-3 space-y-1">
+          <div className="flex items-start justify-between">
+            <h4 className="font-medium text-sm sm:text-base">{med.name}</h4>
+            <Badge variant="outline" className="capitalize">
+              {med.priority}
+            </Badge>
+          </div>
+          <div className="text-sm text-muted-foreground flex flex-wrap gap-2">
+            <span>{med.dose}</span>
+            <span>• {med.route}</span>
+            <span>• {med.freq}</span>
+          </div>
+          <div className="text-xs text-muted-foreground">
+            Start: {new Date(med.start).toLocaleDateString()}
+            {med.end && ` • End: ${new Date(med.end).toLocaleDateString()}`}
+          </div>
+          {med.scheduleTimes && med.scheduleTimes.length > 0 && (
+            <div className="text-xs text-muted-foreground">
+              Times: {med.scheduleTimes.join(", ")}
+            </div>
+          )}
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/components/patient/PatientNotes.tsx
+++ b/src/components/patient/PatientNotes.tsx
@@ -1,0 +1,49 @@
+import { useState, useEffect } from "react";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import type { Note } from "@/types/api";
+import api from "@/lib/api";
+
+interface PatientNotesProps {
+  patientId: string;
+}
+
+export function PatientNotes({ patientId }: PatientNotesProps) {
+  const [notes, setNotes] = useState<Note[]>([]);
+
+  useEffect(() => {
+    api.notes
+      .list(patientId, 50)
+      .then((res) => setNotes(res.items))
+      .catch((err) => console.error(err));
+  }, [patientId]);
+
+  if (notes.length === 0) {
+    return (
+      <div className="text-center py-6 text-muted-foreground text-sm bg-muted/30 rounded-lg border border-dashed">
+        No clinical notes for this patient
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {notes.map((note) => (
+        <Card key={note.noteId} className="p-3">
+          <div className="flex items-start justify-between mb-2">
+            <Badge variant="outline" className="capitalize">
+              {note.category}
+            </Badge>
+            <span className="text-xs text-muted-foreground">
+              {new Date(note.createdAt).toLocaleString()}
+            </span>
+          </div>
+          <p className="text-sm whitespace-pre-wrap">{note.content}</p>
+          <div className="mt-2 text-xs text-muted-foreground">
+            Author: {note.authorId}
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/PatientDetail.tsx
+++ b/src/pages/PatientDetail.tsx
@@ -9,6 +9,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { StageChip } from "@/components/patient/StageChip";
 import { Timeline } from "@/components/patient/Timeline";
 import { PatientTasks } from "@/components/patient/PatientTasks";
+import { PatientNotes } from "@/components/patient/PatientNotes";
+import { PatientMeds } from "@/components/patient/PatientMeds";
 import { QrCode, Copy, Phone, Mail, Calendar } from "lucide-react";
 import api from "@/lib/api";
 import type { Patient, TimelineEntry } from "@/types/api";
@@ -243,12 +245,7 @@ export default function PatientDetail() {
             <Card className="p-4 sm:p-6 min-h-[400px] border border-border/50">
               <div className="space-y-4">
                 <h3 className="font-semibold text-base sm:text-lg">Clinical Notes</h3>
-                <div className="space-y-3">
-                  <div className="text-sm text-muted-foreground bg-muted/30 p-3 rounded-lg border border-dashed">
-                    <p className="text-center py-8">Clinical notes will be displayed here</p>
-                    <p className="text-center text-xs">Patient: {patient.name} • ID: {patient.mrn}</p>
-                  </div>
-                </div>
+                <PatientNotes patientId={patient.mrn} />
               </div>
             </Card>
           </TabsContent>
@@ -271,12 +268,7 @@ export default function PatientDetail() {
             <Card className="p-4 sm:p-6 min-h-[400px] border border-border/50">
               <div className="space-y-4">
                 <h3 className="font-semibold text-base sm:text-lg">Medications</h3>
-                <div className="space-y-3">
-                  <div className="text-sm text-muted-foreground bg-muted/30 p-3 rounded-lg border border-dashed">
-                    <p className="text-center py-8">Medication list will be displayed here</p>
-                    <p className="text-center text-xs">Patient: {patient.name} • ID: {patient.mrn}</p>
-                  </div>
-                </div>
+                <PatientMeds patientId={patient.mrn} />
               </div>
             </Card>
           </TabsContent>


### PR DESCRIPTION
## Summary
- show patient clinical notes and active medications
- hook notes and meds tabs to HMS APIs

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a823461348333841f5f9fb71e83f9