### PR TITLE
feat: add configurable API proxy

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,4 @@
+VITE_API_BASE_URL=/api
+# pick ONE of these targets
+# VITE_PROXY_TARGET=http://localhost:8000
+VITE_PROXY_TARGET=https://o7ykvdqu5pbnr2fhtuoddbgj3y0peneo.lambda-url.us-east-1.on.aws

--- a/seed_and_test.py
+++ b/seed_and_test.py
@@ -24,7 +24,7 @@ What it does (in order):
 
 Usage:
     pip install requests  (and optionally boto3 if you need the Dynamo fallback)
-    python seed_and_test.py --base https://<your-lambda-url> [--prefix myrun] [--region us-east-1] [--table HMS]
+    python seed_and_test.py --base https://o7ykvdqu5pbnr2fhtuoddbgj3y0peneo.lambda-url.us-east-1.on.aws [--prefix myrun] [--region us-east-1] [--table HMS]
 """
 
 import argparse

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,6 @@
 import type { Patient, Task, Note, Medication, Doctor, TimelineEntry } from '@/types/api';
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
+const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api';
 
 function toSnakeCase(obj: Record<string, unknown>): Record<string, unknown> {
   const result: Record<string, unknown> = {};

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "builds": [
+    { "src": "package.json", "use": "@vercel/static-build", "config": { "distDir": "dist" } }
+  ],
+  "rewrites": [
+    {
+      "source": "/api/:path*",
+      "destination": "https://o7ykvdqu5pbnr2fhtuoddbgj3y0peneo.lambda-url.us-east-1.on.aws/:path*"
+    },
+    {
+      "source": "/((?!.*\\.).*)",
+      "destination": "/"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/api/:path*",
+      "headers": [{ "key": "Cache-Control", "value": "no-store" }]
+    }
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,29 +1,27 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
 
-// https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  server: {
-    host: "::",
-    port: 8080,
-    proxy: {
-      '/api': {
-        target: "https://o7ykvdqu5pbnr2fhtuoddbgj3y0peneo.lambda-url.us-east-1.on.aws",
-        changeOrigin: true,
-        rewrite: (p) => p.replace(/^\/api/, ""),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const proxyTarget = env.VITE_PROXY_TARGET || "http://localhost:8000";
+
+  return {
+    server: {
+      host: "::",
+      port: 8080,
+      proxy: {
+        "/api": {
+          target: proxyTarget,
+          changeOrigin: true,
+          rewrite: (p) => p.replace(/^\/api/, ""),
+        },
       },
     },
-  },
-  plugins: [
-    react(),
-    mode === 'development' &&
-    componentTagger(),
-  ].filter(Boolean),
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+    plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
+    resolve: {
+      alias: { "@": path.resolve(__dirname, "./src") },
     },
-  },
-}));
+  };
+});


### PR DESCRIPTION
## Summary
- default API helper to `/api`
- make vite dev proxy target configurable via `VITE_PROXY_TARGET`
- add sample `.env.local` and Vercel rewrite config with provided Lambda URL
- document seeding script usage with the same Lambda URL

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a91dc8c048333b6712aed64c64800