### PR TITLE
Add list/grid patient list view with persistence

### DIFF
--- a/src/components/patient/PatientGridCard.tsx
+++ b/src/components/patient/PatientGridCard.tsx
@@ -1,0 +1,83 @@
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import type { Patient } from "@/types/api";
+import { AlertTriangle } from "lucide-react";
+import { format } from "date-fns";
+
+interface PatientGridCardProps {
+  patient: Patient;
+  onClick?: () => void;
+}
+
+function getPriorityColor(patient: Patient) {
+  const state = patient.currentState?.toLowerCase();
+  if (state === "critical" || state === "icu") return "bg-red-500";
+  if (patient.isUrgent) return "bg-orange-500";
+  return "bg-blue-500";
+}
+
+function abbreviateStatus(status?: string) {
+  if (!status) return "";
+  const clean = status.replace(/[^a-zA-Z]/g, " ");
+  const first = clean.trim().split(" ")[0];
+  return first.slice(0, 3).toLowerCase();
+}
+
+function getDoctorLastName(name?: string) {
+  if (!name) return "";
+  return name.replace(/^Dr\.\s+/i, "").split(" ").pop() || "";
+}
+
+function formatDateShort(date?: string) {
+  if (!date) return "";
+  try {
+    return format(new Date(date), "MMM d");
+  } catch {
+    return "";
+  }
+}
+
+export function PatientGridCard({ patient, onClick }: PatientGridCardProps) {
+  const vitals: any = (patient as any).vitals || {};
+  const bp = typeof vitals.bp === "string" ? vitals.bp.split("/")[0] : "--";
+  const hr = vitals.hr ?? "--";
+  const temp = vitals.temp ?? "--";
+
+  return (
+    <Card
+      onClick={onClick}
+      className="relative aspect-square p-2 hover:shadow-sm transition-shadow cursor-pointer"
+    >
+      <span
+        className={`absolute left-1 top-1 h-2 w-2 rounded-full ${getPriorityColor(
+          patient
+        )}`}
+      />
+      {patient.updateCounter && patient.updateCounter > 5 && (
+        <AlertTriangle className="absolute right-1 top-1 h-4 w-4 text-destructive" />
+      )}
+      <div className="flex h-full flex-col text-xs">
+        <span className="font-bold truncate">{patient.name}</span>
+        {patient.age !== undefined && <span>{patient.age}y</span>}
+        {patient.diagnosis && (
+          <span className="line-clamp-2">{patient.diagnosis}</span>
+        )}
+        {patient.currentState && (
+          <Badge variant="secondary" className="w-min px-1 py-0 mt-1">
+            {abbreviateStatus(patient.currentState)}
+          </Badge>
+        )}
+        {patient.assignedDoctor && (
+          <span>{getDoctorLastName(patient.assignedDoctor)}</span>
+        )}
+        {patient.lastUpdated && <span>{formatDateShort(patient.lastUpdated)}</span>}
+        <div className="mt-auto flex justify-between">
+          <span>{bp}</span>
+          <span>{hr}</span>
+          <span>{temp}°</span>
+        </div>
+      </div>
+    </Card>
+  );
+}
+

--- a/src/components/patient/PatientGridCard.tsx
+++ b/src/components/patient/PatientGridCard.tsx
@@ -1,81 +1,27 @@
 import { Card } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import type { Patient } from "@/types/api";
-import { AlertTriangle } from "lucide-react";
-import { format } from "date-fns";
 
 interface PatientGridCardProps {
   patient: Patient;
   onClick?: () => void;
 }
 
-function getPriorityColor(patient: Patient) {
-  const state = patient.currentState?.toLowerCase();
-  if (state === "critical" || state === "icu") return "bg-red-500";
-  if (patient.isUrgent) return "bg-orange-500";
-  return "bg-blue-500";
-}
-
-function abbreviateStatus(status?: string) {
-  if (!status) return "";
-  const clean = status.replace(/[^a-zA-Z]/g, " ");
-  const first = clean.trim().split(" ")[0];
-  return first.slice(0, 3).toLowerCase();
-}
-
-function getDoctorLastName(name?: string) {
-  if (!name) return "";
-  return name.replace(/^Dr\.\s+/i, "").split(" ").pop() || "";
-}
-
-function formatDateShort(date?: string) {
-  if (!date) return "";
-  try {
-    return format(new Date(date), "MMM d");
-  } catch {
-    return "";
-  }
-}
-
 export function PatientGridCard({ patient, onClick }: PatientGridCardProps) {
-  const vitals: any = (patient as any).vitals || {};
-  const bp = typeof vitals.bp === "string" ? vitals.bp.split("/")[0] : "--";
-  const hr = vitals.hr ?? "--";
-  const temp = vitals.temp ?? "--";
-
   return (
     <Card
       onClick={onClick}
-      className="relative aspect-square p-2 hover:shadow-sm transition-shadow cursor-pointer"
+      className="aspect-square p-2 hover:shadow-sm transition-shadow cursor-pointer"
     >
-      <span
-        className={`absolute left-1 top-1 h-2 w-2 rounded-full ${getPriorityColor(
-          patient
-        )}`}
-      />
-      {patient.updateCounter && patient.updateCounter > 5 && (
-        <AlertTriangle className="absolute right-1 top-1 h-4 w-4 text-destructive" />
-      )}
-      <div className="flex h-full flex-col text-xs">
+      <div className="flex h-full flex-col text-xs space-y-1">
         <span className="font-bold truncate">{patient.name}</span>
-        {patient.age !== undefined && <span>{patient.age}y</span>}
         {patient.diagnosis && (
           <span className="line-clamp-2">{patient.diagnosis}</span>
         )}
-        {patient.currentState && (
-          <Badge variant="secondary" className="w-min px-1 py-0 mt-1">
-            {abbreviateStatus(patient.currentState)}
-          </Badge>
+        {patient.comorbidities && patient.comorbidities.length > 0 && (
+          <span className="line-clamp-2">
+            {patient.comorbidities.join(", ")}
+          </span>
         )}
-        {patient.assignedDoctor && (
-          <span>{getDoctorLastName(patient.assignedDoctor)}</span>
-        )}
-        {patient.lastUpdated && <span>{formatDateShort(patient.lastUpdated)}</span>}
-        <div className="mt-auto flex justify-between">
-          <span>{bp}</span>
-          <span>{hr}</span>
-          <span>{temp}°</span>
-        </div>
       </div>
     </Card>
   );

--- a/src/components/patient/ViewToggle.tsx
+++ b/src/components/patient/ViewToggle.tsx
@@ -1,0 +1,37 @@
+import { LayoutGrid, List } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface ViewToggleProps {
+  mode: "list" | "grid";
+  onChange: (mode: "list" | "grid") => void;
+}
+
+export function ViewToggle({ mode, onChange }: ViewToggleProps) {
+  return (
+    <div className="flex rounded-md bg-muted p-1">
+      <button
+        type="button"
+        aria-label="List view"
+        onClick={() => onChange("list")}
+        className={cn(
+          "flex h-8 w-8 items-center justify-center rounded",
+          mode === "list" && "bg-background shadow"
+        )}
+      >
+        <List className="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        aria-label="Grid view"
+        onClick={() => onChange("grid")}
+        className={cn(
+          "flex h-8 w-8 items-center justify-center rounded",
+          mode === "grid" && "bg-background shadow"
+        )}
+      >
+        <LayoutGrid className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}
+

--- a/src/pages/PatientsList.tsx
+++ b/src/pages/PatientsList.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect } from "react";
 import { Header } from "@/components/layout/Header";
 import { BottomBar } from "@/components/layout/BottomBar";
 import { PatientCard } from "@/components/patient/PatientCard";
+import { PatientGridCard } from "@/components/patient/PatientGridCard";
+import { ViewToggle } from "@/components/patient/ViewToggle";
 import { FilterPopup } from "@/components/patient/FilterPopup";
 import { AddPatientForm } from "@/components/patient/AddPatientForm";
 import { NotificationsPopup } from "@/components/notifications/NotificationsPopup";
@@ -26,6 +28,9 @@ export default function PatientsList() {
   const [showAddPatientForm, setShowAddPatientForm] = useState(false);
   const [showNotifications, setShowNotifications] = useState(false);
   const [patients, setPatients] = useState<Patient[]>(mockPatients);
+  const [viewMode, setViewMode] = useState<'list' | 'grid'>(
+    () => (localStorage.getItem('patientViewMode') as 'list' | 'grid') || 'list'
+  );
   const currentDoctorId = 'doc-abc123';
 
   useEffect(() => {
@@ -44,6 +49,10 @@ export default function PatientsList() {
       })
       .catch((err) => console.error(err));
   }, []);
+
+  useEffect(() => {
+    localStorage.setItem('patientViewMode', viewMode);
+  }, [viewMode]);
 
   // Handle URL parameters for stage filtering
   useEffect(() => {
@@ -140,27 +149,42 @@ export default function PatientsList() {
                 onClearFilters={clearFilters}
                 activeFiltersCount={getActiveFiltersCount()}
               />
-              <Badge variant="secondary">
-                {getFilteredPatients('all').length} patients
-              </Badge>
+              <div className="flex items-center gap-2">
+                <ViewToggle mode={viewMode} onChange={setViewMode} />
+                <Badge variant="secondary">
+                  {getFilteredPatients('all').length} patients
+                </Badge>
+              </div>
             </div>
 
-            {/* Patients Grid */}
-            <div className="grid gap-3">
-              {getFilteredPatients('all').map((patient) => (
-                <PatientCard
-                  key={patient.id}
-                  patient={patient}
-                  onClick={() => navigate(`/patients/${patient.id}`)}
-                />
-              ))}
-            </div>
+            {/* Patients */}
+            {viewMode === 'list' ? (
+              <div className="space-y-3">
+                {getFilteredPatients('all').map((patient) => (
+                  <PatientCard
+                    key={patient.id}
+                    patient={patient}
+                    onClick={() => navigate(`/patients/${patient.id}`)}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="grid grid-cols-3 gap-2">
+                {getFilteredPatients('all').map((patient) => (
+                  <PatientGridCard
+                    key={patient.id}
+                    patient={patient}
+                    onClick={() => navigate(`/patients/${patient.id}`)}
+                  />
+                ))}
+              </div>
+            )}
 
             {getFilteredPatients('all').length === 0 && (
               <div className="text-center py-12">
                 <p className="text-muted-foreground">No patients found matching your criteria</p>
-                <Button 
-                  variant="outline" 
+                <Button
+                  variant="outline"
                   className="mt-4"
                   onClick={() => {
                     setSearchQuery('');
@@ -186,29 +210,44 @@ export default function PatientsList() {
                 onClearFilters={clearFilters}
                 activeFiltersCount={getActiveFiltersCount()}
               />
-              <Badge variant="secondary">
-                {getFilteredPatients('my').length} patients
-              </Badge>
+              <div className="flex items-center gap-2">
+                <ViewToggle mode={viewMode} onChange={setViewMode} />
+                <Badge variant="secondary">
+                  {getFilteredPatients('my').length} patients
+                </Badge>
+              </div>
             </div>
 
-            {/* My Patients Grid */}
-            <div className="grid gap-3">
-              {getFilteredPatients('my').map((patient) => (
-                <PatientCard
-                  key={patient.id}
-                  patient={patient}
-                  onClick={() => navigate(`/patients/${patient.id}`)}
-                />
-              ))}
-            </div>
+            {/* My Patients */}
+            {viewMode === 'list' ? (
+              <div className="space-y-3">
+                {getFilteredPatients('my').map((patient) => (
+                  <PatientCard
+                    key={patient.id}
+                    patient={patient}
+                    onClick={() => navigate(`/patients/${patient.id}`)}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="grid grid-cols-3 gap-2">
+                {getFilteredPatients('my').map((patient) => (
+                  <PatientGridCard
+                    key={patient.id}
+                    patient={patient}
+                    onClick={() => navigate(`/patients/${patient.id}`)}
+                  />
+                ))}
+              </div>
+            )}
 
             {getFilteredPatients('my').length === 0 && (
               <div className="text-center py-12">
                 {getActiveFiltersCount() > 0 || searchQuery ? (
                   <>
                     <p className="text-muted-foreground">No patients assigned to you matching your criteria</p>
-                    <Button 
-                      variant="outline" 
+                    <Button
+                      variant="outline"
                       className="mt-4"
                       onClick={() => {
                         setSearchQuery('');


### PR DESCRIPTION
## Summary
- add view mode state persisted in localStorage to remember list or grid
- create compact grid patient card and reusable toggle component
- integrate view mode toggle into patient list for list/grid layouts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689af057e4988333aa0cf6fbcfe2db63