### PR TITLE
feat: dynamic dashboard metrics

### DIFF
--- a/src/components/dashboard/MindfulnessTile.tsx
+++ b/src/components/dashboard/MindfulnessTile.tsx
@@ -1,0 +1,134 @@
+import { Card } from "@/components/ui/card";
+import { Heart, Smile, RefreshCw } from "lucide-react";
+import { useEffect, useState } from "react";
+
+interface Activity {
+  type: string;
+  icon: typeof Heart;
+  title: string;
+  subtitle: string;
+  color: string;
+  bg: string;
+  border: string;
+}
+
+const mindfulnessActivities: Activity[] = [
+  {
+    type: "breathing",
+    icon: Heart,
+    title: "Take 10 Deep Breaths",
+    subtitle: "Reset your mind",
+    color: "text-pink-600",
+    bg: "bg-pink-50",
+    border: "border-pink-200",
+  },
+  {
+    type: "balance",
+    icon: Smile,
+    title: "How do you feel?",
+    subtitle: "Check in with yourself",
+    color: "text-purple-600",
+    bg: "bg-purple-50",
+    border: "border-purple-200",
+  },
+  {
+    type: "reminder",
+    icon: Heart,
+    title: "Care for yourself too",
+    subtitle: "You matter as much as your patients",
+    color: "text-green-600",
+    bg: "bg-green-50",
+    border: "border-green-200",
+  },
+  {
+    type: "wellness",
+    icon: RefreshCw,
+    title: "Rest well, eat well",
+    subtitle: "Your wellbeing is essential",
+    color: "text-blue-600",
+    bg: "bg-blue-50",
+    border: "border-blue-200",
+  },
+  {
+    type: "balance-check",
+    icon: Smile,
+    title: "Have you lost your balance?",
+    subtitle: "It's okay to pause",
+    color: "text-orange-600",
+    bg: "bg-orange-50",
+    border: "border-orange-200",
+  },
+  {
+    type: "joy",
+    icon: Heart,
+    title: "Enjoy life",
+    subtitle: "Find moments of joy today",
+    color: "text-rose-600",
+    bg: "bg-rose-50",
+    border: "border-rose-200",
+  },
+  {
+    type: "strength",
+    icon: RefreshCw,
+    title: "Don't break yourself",
+    subtitle: "While helping others heal",
+    color: "text-indigo-600",
+    bg: "bg-indigo-50",
+    border: "border-indigo-200",
+  },
+  {
+    type: "gratitude",
+    icon: Smile,
+    title: "You're making a difference",
+    subtitle: "Your work matters",
+    color: "text-teal-600",
+    bg: "bg-teal-50",
+    border: "border-teal-200",
+  },
+];
+
+export function MindfulnessTile() {
+  const [currentActivity, setCurrentActivity] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCurrentActivity((prev) => (prev + 1) % mindfulnessActivities.length);
+    }, 3000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const activity = mindfulnessActivities[currentActivity];
+  const Icon = activity.icon;
+
+  return (
+    <Card
+      className={`${activity.bg} ${activity.border} border p-4 cursor-pointer hover:shadow-md transition-all`}
+      onClick={() =>
+        setCurrentActivity((prev) => (prev + 1) % mindfulnessActivities.length)
+      }
+    >
+      <div className="flex items-center justify-between mb-2">
+        <Icon className={`w-5 h-5 ${activity.color}`} />
+        <div className="flex gap-1">
+          {mindfulnessActivities.map((_, index) => (
+            <div
+              key={index}
+              className={`w-1.5 h-1.5 rounded-full transition-colors duration-300 ${
+                index === currentActivity
+                  ? activity.color.replace("text-", "bg-")
+                  : "bg-gray-300"
+              }`}
+            />
+          ))}
+        </div>
+      </div>
+      <div className="text-sm font-semibold text-gray-900 mb-1 leading-tight">
+        {activity.title}
+      </div>
+      <div className="text-xs text-gray-600 leading-relaxed">
+        {activity.subtitle}
+      </div>
+    </Card>
+  );
+}
+

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -7,7 +7,6 @@ import { Button } from "@/components/ui/button";
 import {
   Users,
   AlertTriangle,
-  CheckCircle,
   Clock,
   TrendingUp,
   Calendar,
@@ -15,6 +14,7 @@ import {
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import api from "@/lib/api";
+import { MindfulnessTile } from "@/components/dashboard/MindfulnessTile";
 
 type StageEntry = {
   stage: string;
@@ -52,7 +52,6 @@ export default function Dashboard() {
     totalPatients: 0,
     tasksDue: 0,
     urgentAlerts: 0,
-    completedToday: 0,
   });
   const [stageHeatMap, setStageHeatMap] = useState<StageEntry[]>([]);
 
@@ -68,18 +67,10 @@ export default function Dashboard() {
         const totalPatients = patients.length;
         const tasksDue = allTasks.filter((t) => t.status !== "done").length;
         const urgentAlerts = patients.filter((p) => p.isUrgent).length;
-        const today = new Date().toDateString();
-        const completedToday = allTasks.filter(
-          (t) =>
-            t.status === "done" &&
-            new Date(t.updatedAt).toDateString() === today
-        ).length;
-
         setKpiData({
           totalPatients,
           tasksDue,
           urgentAlerts,
-          completedToday,
         });
 
         const stageCounts: Record<string, number> = {};
@@ -164,14 +155,7 @@ export default function Dashboard() {
             variant="urgent"
             onClick={() => navigate('/urgent-alerts')}
           />
-          <KPITile
-            title="Completed Today"
-            value={kpiData.completedToday}
-            icon={CheckCircle}
-            variant="stable"
-            trend={{ value: 12, isPositive: true }}
-            onClick={() => navigate('/completed-today')}
-          />
+          <MindfulnessTile />
         </div>
 
         {/* Stage Heat Map */}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,33 +4,116 @@ import { KPITile } from "@/components/dashboard/KPITile";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Users, AlertTriangle, CheckCircle, Clock, TrendingUp, Calendar } from "lucide-react";
+import {
+  Users,
+  AlertTriangle,
+  CheckCircle,
+  Clock,
+  TrendingUp,
+  Calendar,
+} from "lucide-react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import api from "@/lib/api";
 
-// Mock data - replace with real API calls
-const mockKPIData = {
-  totalPatients: 47,
-  tasksDue: 12,
-  urgentAlerts: 3,
-  completedToday: 28
+type StageEntry = {
+  stage: string;
+  count: number;
+  variant: "default" | "urgent" | "stable" | "caution";
 };
 
 const mockUpcomingProcedures = [
-  { id: '1', patient: 'John Smith', procedure: 'Appendectomy', time: '14:30', surgeon: 'Dr. Wilson' },
-  { id: '2', patient: 'Maria Garcia', procedure: 'Knee Replacement', time: '16:00', surgeon: 'Dr. Chen' },
-  { id: '3', patient: 'David Johnson', procedure: 'Cardiac Stent', time: '09:15', surgeon: 'Dr. Patel' }
-];
-
-const mockStageHeatMap = [
-  { stage: 'Pre-Op', count: 8, variant: 'caution' as const },
-  { stage: 'Surgery', count: 3, variant: 'urgent' as const },
-  { stage: 'Post-Op', count: 12, variant: 'stable' as const },
-  { stage: 'Recovery', count: 15, variant: 'default' as const },
-  { stage: 'Discharge', count: 9, variant: 'stable' as const }
+  {
+    id: "1",
+    patient: "John Smith",
+    procedure: "Appendectomy",
+    time: "14:30",
+    surgeon: "Dr. Wilson",
+  },
+  {
+    id: "2",
+    patient: "Maria Garcia",
+    procedure: "Knee Replacement",
+    time: "16:00",
+    surgeon: "Dr. Chen",
+  },
+  {
+    id: "3",
+    patient: "David Johnson",
+    procedure: "Cardiac Stent",
+    time: "09:15",
+    surgeon: "Dr. Patel",
+  },
 ];
 
 export default function Dashboard() {
   const navigate = useNavigate();
+  const [kpiData, setKpiData] = useState({
+    totalPatients: 0,
+    tasksDue: 0,
+    urgentAlerts: 0,
+    completedToday: 0,
+  });
+  const [stageHeatMap, setStageHeatMap] = useState<StageEntry[]>([]);
+
+  useEffect(() => {
+    const fetchDashboardData = async () => {
+      try {
+        const patients = await api.patients.list();
+        const tasksArrays = await Promise.all(
+          patients.map((p) => api.tasks.list(p.id).catch(() => []))
+        );
+        const allTasks = tasksArrays.flat();
+
+        const totalPatients = patients.length;
+        const tasksDue = allTasks.filter((t) => t.status !== "done").length;
+        const urgentAlerts = patients.filter((p) => p.isUrgent).length;
+        const today = new Date().toDateString();
+        const completedToday = allTasks.filter(
+          (t) =>
+            t.status === "done" &&
+            new Date(t.updatedAt).toDateString() === today
+        ).length;
+
+        setKpiData({
+          totalPatients,
+          tasksDue,
+          urgentAlerts,
+          completedToday,
+        });
+
+        const stageCounts: Record<string, number> = {};
+        patients.forEach((p) => {
+          const stage = p.currentState || "Unknown";
+          stageCounts[stage] = (stageCounts[stage] || 0) + 1;
+        });
+
+        const stages: StageEntry[] = Object.entries(stageCounts).map(
+          ([stage, count]) => {
+            const key = stage.toLowerCase();
+            const variant =
+              key === "surgery"
+                ? "urgent"
+                : key === "pre-op"
+                ? "caution"
+                : key === "post-op" || key === "discharge"
+                ? "stable"
+                : "default";
+            const label = stage.replace(/\b\w/g, (c) => c.toUpperCase());
+            return { stage: label, count, variant };
+          }
+        );
+
+        setStageHeatMap(stages);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+
+    fetchDashboardData();
+    const id = setInterval(fetchDashboardData, 60000);
+    return () => clearInterval(id);
+  }, []);
 
   return (
     <div className="min-h-screen bg-background pb-20">
@@ -62,28 +145,28 @@ export default function Dashboard() {
         <div className="grid grid-cols-2 gap-4">
           <KPITile
             title="Total Patients"
-            value={mockKPIData.totalPatients}
+            value={kpiData.totalPatients}
             icon={Users}
             trend={{ value: 5, isPositive: true }}
             onClick={() => navigate('/patients')}
           />
           <KPITile
             title="Tasks Due"
-            value={mockKPIData.tasksDue}
+            value={kpiData.tasksDue}
             icon={Clock}
             variant="caution"
             onClick={() => navigate('/tasks-due')}
           />
           <KPITile
             title="Urgent Alerts"
-            value={mockKPIData.urgentAlerts}
+            value={kpiData.urgentAlerts}
             icon={AlertTriangle}
             variant="urgent"
             onClick={() => navigate('/urgent-alerts')}
           />
           <KPITile
             title="Completed Today"
-            value={mockKPIData.completedToday}
+            value={kpiData.completedToday}
             icon={CheckCircle}
             variant="stable"
             trend={{ value: 12, isPositive: true }}
@@ -98,21 +181,30 @@ export default function Dashboard() {
             <TrendingUp className="h-4 w-4 text-muted-foreground" />
           </div>
           <div className="grid grid-cols-5 gap-2">
-            {mockStageHeatMap.map((stage) => (
+            {stageHeatMap.map((stage) => (
               <div
                 key={stage.stage}
                 className="text-center p-2 rounded-lg border cursor-pointer hover:shadow-sm transition-shadow"
-                onClick={() => navigate(`/patients?stage=${stage.stage.toLowerCase().replace('-', '')}`)}
+                onClick={() =>
+                  navigate(`/patients?stage=${stage.stage.toLowerCase().replace('-', '')}`)
+                }
               >
-                <div className={`text-xl font-bold mb-1 ${
-                  stage.variant === 'urgent' ? 'text-urgent' :
-                  stage.variant === 'stable' ? 'text-stable' :
-                  stage.variant === 'caution' ? 'text-caution' :
-                  'text-medical'
-                }`}>
+                <div
+                  className={`text-xl font-bold mb-1 ${
+                    stage.variant === 'urgent'
+                      ? 'text-urgent'
+                      : stage.variant === 'stable'
+                      ? 'text-stable'
+                      : stage.variant === 'caution'
+                      ? 'text-caution'
+                      : 'text-medical'
+                  }`}
+                >
                   {stage.count}
                 </div>
-                <div className="text-xs text-muted-foreground break-words leading-tight">{stage.stage}</div>
+                <div className="text-xs text-muted-foreground break-words leading-tight">
+                  {stage.stage}
+                </div>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- compute KPI tiles and patient stage heat map from live API data
- refresh dashboard metrics periodically to stay up to date

## Testing
- `npm run lint` *(fails: Unexpected any in AddMedication.tsx and others)*

------
https://chatgpt.com/codex/tasks/task_e_689af749b8c48333a1bf508231bf36f4