### PR TITLE
feat: edit patient, task and note details

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,9 @@ import PatientQRView from "./pages/PatientQRView";
 import AddNote from "./pages/AddNote";
 import AddMedication from "./pages/AddMedication";
 import AddTask from "./pages/AddTask";
+import EditPatient from "./pages/EditPatient";
+import EditTask from "./pages/EditTask";
+import EditNote from "./pages/EditNote";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -32,9 +35,12 @@ const App = () => (
           <Route path="/" element={<Dashboard />} />
           <Route path="/patients" element={<PatientsList />} />
           <Route path="/patients/:id" element={<PatientDetail />} />
+          <Route path="/patients/:id/edit" element={<EditPatient />} />
           <Route path="/patients/:id/add-note" element={<AddNote />} />
+          <Route path="/patients/:id/notes/:noteId/edit" element={<EditNote />} />
           <Route path="/patients/:id/add-med" element={<AddMedication />} />
           <Route path="/patients/:id/add-task" element={<AddTask />} />
+          <Route path="/patients/:id/tasks/:taskId/edit" element={<EditTask />} />
           <Route path="/tasks" element={<Tasks />} />
           <Route path="/tasks-due" element={<TasksDue />} />
           <Route path="/urgent-alerts" element={<UrgentAlerts />} />

--- a/src/components/patient/PatientNotes.tsx
+++ b/src/components/patient/PatientNotes.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect } from "react";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import type { Note } from "@/types/api";
 import api from "@/lib/api";
+import { useNavigate } from "react-router-dom";
 
 interface PatientNotesProps {
   patientId: string;
@@ -10,6 +12,7 @@ interface PatientNotesProps {
 
 export function PatientNotes({ patientId }: PatientNotesProps) {
   const [notes, setNotes] = useState<Note[]>([]);
+  const navigate = useNavigate();
 
   useEffect(() => {
     api.notes
@@ -39,8 +42,16 @@ export function PatientNotes({ patientId }: PatientNotesProps) {
             </span>
           </div>
           <p className="text-sm whitespace-pre-wrap">{note.content}</p>
-          <div className="mt-2 text-xs text-muted-foreground">
-            Author: {note.authorId}
+          <div className="mt-2 flex items-center justify-between text-xs text-muted-foreground">
+            <span>Author: {note.authorId}</span>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-6 px-2"
+              onClick={() => navigate(`/patients/${patientId}/notes/${note.noteId}/edit`)}
+            >
+              Edit
+            </Button>
           </div>
         </Card>
       ))}

--- a/src/components/patient/PatientTasks.tsx
+++ b/src/components/patient/PatientTasks.tsx
@@ -4,9 +4,10 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Task } from "@/types/api";
-import { Clock, User, Calendar, Flag, CheckCircle2 } from "lucide-react";
+import { Clock, User, Calendar, Flag, CheckCircle2, Pencil } from "lucide-react";
 import { cn } from "@/lib/utils";
 import api from "@/lib/api";
+import { useNavigate } from "react-router-dom";
 
 interface PatientTasksProps {
   patientId: string;
@@ -15,9 +16,10 @@ interface PatientTasksProps {
 interface TaskCardProps {
   task: Task;
   onStatusChange: (taskId: string, newStatus: Task['status']) => void;
+  onEdit: (taskId: string) => void;
 }
 
-function TaskCard({ task, onStatusChange }: TaskCardProps) {
+function TaskCard({ task, onStatusChange, onEdit }: TaskCardProps) {
   const getPriorityColor = (priority: Task['priority']) => {
     switch (priority) {
       case 'urgent': return 'text-urgent';
@@ -83,8 +85,16 @@ function TaskCard({ task, onStatusChange }: TaskCardProps) {
             {task.assigneeId.slice(0, 2).toUpperCase()}
           </AvatarFallback>
         </Avatar>
-        
+
         <div className="flex gap-1">
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-6 px-2 text-xs"
+            onClick={() => onEdit(task.taskId)}
+          >
+            <Pencil className="h-3 w-3" />
+          </Button>
           {task.status !== 'done' && (
             <Button
               size="sm"
@@ -103,6 +113,7 @@ function TaskCard({ task, onStatusChange }: TaskCardProps) {
 
 export function PatientTasks({ patientId }: PatientTasksProps) {
   const [tasks, setTasks] = useState<Task[]>([]);
+  const navigate = useNavigate();
 
   useEffect(() => {
     api.tasks
@@ -122,6 +133,10 @@ export function PatientTasks({ patientId }: PatientTasksProps) {
       .catch((err) => console.error(err));
   };
 
+  const handleEdit = (taskId: string) => {
+    navigate(`/patients/${patientId}/tasks/${taskId}/edit`);
+  };
+
   const pendingTasks = tasks.filter(task => task.status !== 'done');
   const completedTasks = tasks.filter(task => task.status === 'done');
 
@@ -137,6 +152,7 @@ export function PatientTasks({ patientId }: PatientTasksProps) {
                 key={task.taskId}
                 task={task}
                 onStatusChange={handleStatusChange}
+                onEdit={handleEdit}
               />
             ))}
           </div>
@@ -157,6 +173,7 @@ export function PatientTasks({ patientId }: PatientTasksProps) {
                 key={task.taskId}
                 task={task}
                 onStatusChange={handleStatusChange}
+                onEdit={handleEdit}
               />
             ))}
           </div>

--- a/src/pages/EditNote.tsx
+++ b/src/pages/EditNote.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Header } from "@/components/layout/Header";
+import { BottomBar } from "@/components/layout/BottomBar";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import api from "@/lib/api";
+import type { Note } from "@/types/api";
+
+export default function EditNote() {
+  const { id, noteId } = useParams();
+  const navigate = useNavigate();
+  const [category, setCategory] = useState<Note['category'] | "">("");
+  const [content, setContent] = useState("");
+  const [authorId, setAuthorId] = useState("");
+  const [patientName, setPatientName] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => { document.title = `Edit Note | Clinical Canvas`; }, []);
+
+  useEffect(() => {
+    if (!id || !noteId) return;
+    api.patients.get(id).then(p => setPatientName(p.name)).catch(() => {});
+    api.notes.list(id, 50).then(res => {
+      const note = res.items.find(n => n.noteId === noteId);
+      if (note) {
+        setCategory(note.category);
+        setContent(note.content);
+        setAuthorId(note.authorId);
+      }
+    }).catch(() => {});
+  }, [id, noteId]);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!id || !noteId || !category || !content) return;
+    setSubmitting(true);
+    try {
+      await api.notes.update(id, noteId, { category, content });
+      navigate(`/patients/${id}`);
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background pb-20">
+      <Header title="Edit Note" showBack onBack={() => navigate(-1)} />
+      <main className="p-4">
+        <Card className="p-4 max-w-xl mx-auto">
+          <h1 className="text-lg font-semibold mb-4">Edit Note {patientName ? `for ${patientName}` : ""}</h1>
+          <form onSubmit={onSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label>Category</Label>
+              <Select value={category} onValueChange={v => setCategory(v as Note['category'])}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select category" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="doctorNote">Doctor Note</SelectItem>
+                  <SelectItem value="nurseNote">Nurse Note</SelectItem>
+                  <SelectItem value="pharmacy">Pharmacy</SelectItem>
+                  <SelectItem value="discharge">Discharge</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Author ID</Label>
+              <input
+                className="w-full h-10 rounded-md border bg-background px-3 text-sm"
+                value={authorId}
+                onChange={e => setAuthorId(e.target.value)}
+                placeholder="e.g., doc-abc123"
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Content</Label>
+              <Textarea value={content} onChange={e => setContent(e.target.value)} rows={6} required />
+            </div>
+            <div className="flex gap-3 pt-2">
+              <Button type="submit" disabled={submitting} className="flex-1">{submitting ? "Saving..." : "Save Note"}</Button>
+              <Button type="button" variant="outline" onClick={() => navigate(-1)}>Cancel</Button>
+            </div>
+          </form>
+        </Card>
+      </main>
+      <BottomBar />
+    </div>
+  );
+}

--- a/src/pages/EditPatient.tsx
+++ b/src/pages/EditPatient.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Header } from "@/components/layout/Header";
+import { BottomBar } from "@/components/layout/BottomBar";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import api from "@/lib/api";
+
+export default function EditPatient() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [form, setForm] = useState({
+    name: "",
+    age: "",
+    sex: "" as string,
+    diagnosis: "",
+    pathway: "" as "surgical" | "consultation" | "emergency" | "",
+    assignedDoctor: "",
+    assignedDoctorId: "",
+  });
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => { document.title = `Edit Patient | Clinical Canvas`; }, []);
+
+  useEffect(() => {
+    if (!id) return;
+    api.patients.get(id).then(p => {
+      setForm({
+        name: p.name || "",
+        age: p.age ? String(p.age) : "",
+        sex: p.sex || "",
+        diagnosis: p.diagnosis || "",
+        pathway: (p.pathway as "surgical" | "consultation" | "emergency" | "") || "",
+        assignedDoctor: p.assignedDoctor || "",
+        assignedDoctorId: p.assignedDoctorId || "",
+      });
+    }).catch(() => {});
+  }, [id]);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!id) return;
+    setSubmitting(true);
+    try {
+      const payload: Partial<import("@/types/api").Patient> = {
+        name: form.name,
+        diagnosis: form.diagnosis,
+        assignedDoctor: form.assignedDoctor,
+        assignedDoctorId: form.assignedDoctorId,
+      };
+      if (form.age) payload.age = Number(form.age);
+      if (form.sex) payload.sex = form.sex;
+      if (form.pathway) payload.pathway = form.pathway;
+      await api.patients.update(id, payload);
+      navigate(`/patients/${id}`);
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background pb-20">
+      <Header title="Edit Patient" showBack onBack={() => navigate(-1)} />
+      <main className="p-4">
+        <Card className="p-4 max-w-xl mx-auto">
+          <h1 className="text-lg font-semibold mb-4">Edit Patient</h1>
+          <form onSubmit={onSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label>Name</Label>
+              <Input value={form.name} onChange={e => setForm({ ...form, name: e.target.value })} required />
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-2">
+                <Label>Age</Label>
+                <Input type="number" value={form.age} onChange={e => setForm({ ...form, age: e.target.value })} />
+              </div>
+              <div className="space-y-2">
+                <Label>Sex</Label>
+                <Select value={form.sex} onValueChange={v => setForm({ ...form, sex: v })}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="male">Male</SelectItem>
+                    <SelectItem value="female">Female</SelectItem>
+                    <SelectItem value="other">Other</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>Diagnosis</Label>
+              <Input value={form.diagnosis} onChange={e => setForm({ ...form, diagnosis: e.target.value })} />
+            </div>
+            <div className="space-y-2">
+              <Label>Pathway</Label>
+              <Select value={form.pathway} onValueChange={v => setForm({ ...form, pathway: v as "surgical" | "consultation" | "emergency" | "" })}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select pathway" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="surgical">Surgical</SelectItem>
+                  <SelectItem value="consultation">Consultation</SelectItem>
+                  <SelectItem value="emergency">Emergency</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Assigned Doctor</Label>
+              <Input value={form.assignedDoctor} onChange={e => setForm({ ...form, assignedDoctor: e.target.value })} />
+            </div>
+            <div className="space-y-2">
+              <Label>Assigned Doctor ID</Label>
+              <Input value={form.assignedDoctorId} onChange={e => setForm({ ...form, assignedDoctorId: e.target.value })} />
+            </div>
+            <div className="flex gap-3 pt-2">
+              <Button type="submit" disabled={submitting} className="flex-1">{submitting ? "Saving..." : "Save"}</Button>
+              <Button type="button" variant="outline" onClick={() => navigate(-1)}>Cancel</Button>
+            </div>
+          </form>
+        </Card>
+      </main>
+      <BottomBar />
+    </div>
+  );
+}

--- a/src/pages/EditTask.tsx
+++ b/src/pages/EditTask.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Header } from "@/components/layout/Header";
+import { BottomBar } from "@/components/layout/BottomBar";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import api from "@/lib/api";
+import type { Task, Doctor } from "@/types/api";
+
+export default function EditTask() {
+  const { id, taskId } = useParams();
+  const navigate = useNavigate();
+  const [patientName, setPatientName] = useState("");
+  const [department, setDepartment] = useState("");
+  const [doctors, setDoctors] = useState<Doctor[]>([]);
+  const [form, setForm] = useState({
+    title: "",
+    type: "" as Task['type'] | "",
+    date: "",
+    time: "",
+    assigneeId: "",
+    priority: "medium" as Task['priority'],
+    status: "open" as Task['status'],
+  });
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => { document.title = `Edit Task | Clinical Canvas`; }, []);
+
+  useEffect(() => {
+    if (!id) return;
+    api.patients.get(id).then(p => {
+      setPatientName(p.name);
+      setDepartment(p.department || "");
+    }).catch(() => {});
+  }, [id]);
+
+  useEffect(() => {
+    if (!id || !taskId) return;
+    api.tasks.list(id).then(ts => {
+      const t = ts.find(t => t.taskId === taskId);
+      if (t) {
+        const due = new Date(t.due);
+        setForm({
+          title: t.title,
+          type: t.type,
+          date: due.toISOString().slice(0, 10),
+          time: due.toISOString().slice(11, 16),
+          assigneeId: t.assigneeId,
+          priority: t.priority,
+          status: t.status,
+        });
+      }
+    }).catch(() => {});
+  }, [id, taskId]);
+
+  useEffect(() => {
+    if (!department) return;
+    api.doctors.list(department).then(setDoctors).catch(() => {});
+  }, [department]);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!id || !taskId || !form.type || !form.assigneeId || !form.date || !form.time) return;
+    setSubmitting(true);
+    try {
+      const due = new Date(`${form.date}T${form.time}`);
+      const payload: Partial<Task> = {
+        title: form.title,
+        type: form.type,
+        due: due.toISOString(),
+        assigneeId: form.assigneeId,
+        priority: form.priority,
+        status: form.status,
+      };
+      await api.tasks.update(id, taskId, payload);
+      navigate(`/patients/${id}`);
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background pb-20">
+      <Header title="Edit Task" showBack onBack={() => navigate(-1)} />
+      <main className="p-4">
+        <Card className="p-4 max-w-xl mx-auto">
+          <h1 className="text-lg font-semibold mb-4">Edit Task {patientName ? `for ${patientName}` : ""}</h1>
+          <form onSubmit={onSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label>Task Type</Label>
+              <Select value={form.type} onValueChange={v => setForm({ ...form, type: v as Task['type'] })}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select type" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="lab">Lab</SelectItem>
+                  <SelectItem value="medication">Medication</SelectItem>
+                  <SelectItem value="procedure">Procedure</SelectItem>
+                  <SelectItem value="assessment">Assessment</SelectItem>
+                  <SelectItem value="discharge">Discharge</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Title/Description</Label>
+              <Input value={form.title} onChange={e => setForm({ ...form, title: e.target.value })} />
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-2">
+                <Label>Date</Label>
+                <Input type="date" value={form.date} onChange={e => setForm({ ...form, date: e.target.value })} required />
+              </div>
+              <div className="space-y-2">
+                <Label>Time</Label>
+                <Input type="time" value={form.time} onChange={e => setForm({ ...form, time: e.target.value })} required />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>Assignee</Label>
+              <Select value={form.assigneeId} onValueChange={v => setForm({ ...form, assigneeId: v })}>
+                <SelectTrigger>
+                  <SelectValue placeholder={doctors.length ? "Select doctor" : "Enter assignee id"} />
+                </SelectTrigger>
+                <SelectContent>
+                  {doctors.map(d => (
+                    <SelectItem key={d.doctorId} value={d.doctorId}>{d.name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Priority</Label>
+              <Select value={form.priority} onValueChange={v => setForm({ ...form, priority: v as Task['priority'] })}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="low">Low</SelectItem>
+                  <SelectItem value="medium">Medium</SelectItem>
+                  <SelectItem value="high">High</SelectItem>
+                  <SelectItem value="urgent">Urgent</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Status</Label>
+              <Select value={form.status} onValueChange={v => setForm({ ...form, status: v as Task['status'] })}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="open">Open</SelectItem>
+                  <SelectItem value="in-progress">In Progress</SelectItem>
+                  <SelectItem value="done">Done</SelectItem>
+                  <SelectItem value="cancelled">Cancelled</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex gap-3 pt-2">
+              <Button type="submit" disabled={submitting} className="flex-1">{submitting ? "Saving..." : "Save Task"}</Button>
+              <Button type="button" variant="outline" onClick={() => navigate(-1)}>Cancel</Button>
+            </div>
+          </form>
+        </Card>
+      </main>
+      <BottomBar />
+    </div>
+  );
+}

--- a/src/pages/PatientDetail.tsx
+++ b/src/pages/PatientDetail.tsx
@@ -11,7 +11,7 @@ import { Timeline } from "@/components/patient/Timeline";
 import { PatientTasks } from "@/components/patient/PatientTasks";
 import { PatientNotes } from "@/components/patient/PatientNotes";
 import { PatientMeds } from "@/components/patient/PatientMeds";
-import { QrCode, Copy, Phone, Mail, Calendar, ListTodo, FileText, Pill } from "lucide-react";
+import { QrCode, Copy, Phone, Mail, Calendar, ListTodo, FileText, Pill, Pencil } from "lucide-react";
 import { ArcSpeedDial } from "@/components/patient/ArcSpeedDial";
 import api from "@/lib/api";
 import type { Patient, TimelineEntry } from "@/types/api";
@@ -125,10 +125,21 @@ export default function PatientDetail() {
                 </div>
               </div>
             </div>
-            <Button variant="outline" size="sm" className="flex-shrink-0 w-full sm:w-auto">
-              <QrCode className="h-4 w-4 mr-2" />
-              QR Code
-            </Button>
+            <div className="flex flex-col sm:flex-row gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                className="flex-shrink-0 w-full sm:w-auto"
+                onClick={() => navigate(`/patients/${id}/edit`)}
+              >
+                <Pencil className="h-4 w-4 mr-2" />
+                Edit
+              </Button>
+              <Button variant="outline" size="sm" className="flex-shrink-0 w-full sm:w-auto">
+                <QrCode className="h-4 w-4 mr-2" />
+                QR Code
+              </Button>
+            </div>
           </div>
 
           <div className="space-y-3 sm:space-y-4">


### PR DESCRIPTION
## Summary
- add pages and routes to edit patient, task and note information
- expose edit actions in patient detail, tasks and notes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bfe3efc948333a3385b6789f42dcd