### PR TITLE
feat: add gestures for labs access

### DIFF
--- a/src/components/patient/PatientCard.tsx
+++ b/src/components/patient/PatientCard.tsx
@@ -1,7 +1,6 @@
 import { useRef, useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { StageChip } from "./StageChip";
 import { UpdateRing } from "./UpdateRing";
 import { QRCodeGenerator } from "@/components/qr/QRCodeGenerator";
@@ -16,10 +15,22 @@ interface PatientCardProps {
 export function PatientCard({ patient, onClick }: PatientCardProps) {
   const [showQR, setShowQR] = useState(false);
   const touchStartX = useRef<number | null>(null);
+  const [translateX, setTranslateX] = useState(0);
+  const [isSwiping, setIsSwiping] = useState(false);
   const labsUrl = `http://115.241.194.20/LIS/Reports/Patient_Report.aspx?prno=${patient.mrn}`;
 
   const handleTouchStart = (e: React.TouchEvent) => {
     touchStartX.current = e.changedTouches[0].clientX;
+    setIsSwiping(true);
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (touchStartX.current !== null) {
+      const diff = touchStartX.current - e.changedTouches[0].clientX;
+      if (diff > 0) {
+        setTranslateX(Math.min(diff, 80));
+      }
+    }
   };
 
   const handleTouchEnd = (e: React.TouchEvent) => {
@@ -29,6 +40,8 @@ export function PatientCard({ patient, onClick }: PatientCardProps) {
         window.open(labsUrl, "_blank");
       }
     }
+    setTranslateX(0);
+    setIsSwiping(false);
   };
   const getStageVariant = (stage: string) => {
     switch (stage.toLowerCase()) {
@@ -74,12 +87,20 @@ export function PatientCard({ patient, onClick }: PatientCardProps) {
   };
 
   return (
-    <Card
-      className={`p-4 hover:shadow-md transition-shadow cursor-pointer ${getCardColorClass(patient.currentState)}`}
-      onClick={onClick}
+    <div
+      className="relative"
       onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}
     >
+      <div className="absolute inset-0 flex items-center justify-end pr-4 bg-primary text-primary-foreground rounded-lg">
+        Labs
+      </div>
+      <Card
+        className={`p-4 hover:shadow-md transition-shadow cursor-pointer ${getCardColorClass(patient.currentState)}`}
+        onClick={onClick}
+        style={{ transform: `translateX(-${translateX}px)`, transition: isSwiping ? "none" : "transform 0.2s ease-out" }}
+      >
       <div className="flex items-start gap-3">
         {/* Update Ring */}
         <div className="flex-shrink-0">
@@ -146,7 +167,7 @@ export function PatientCard({ patient, onClick }: PatientCardProps) {
           </button>
         </div>
       </div>
-      
+
       {showQR && (
         <div className="mt-4 p-4 bg-muted/50 rounded-lg flex flex-col items-center gap-2">
           <QRCodeGenerator value={patient.qrCode} size={120} />
@@ -155,19 +176,7 @@ export function PatientCard({ patient, onClick }: PatientCardProps) {
           </p>
         </div>
       )}
-
-      <div className="mt-4 flex">
-        <Button
-          variant="secondary"
-          size="sm"
-          onClick={(e) => {
-            e.stopPropagation();
-            window.open(labsUrl, "_blank");
-          }}
-        >
-          Labs
-        </Button>
-      </div>
-    </Card>
+      </Card>
+    </div>
   );
 }

--- a/src/components/patient/PatientGridCard.tsx
+++ b/src/components/patient/PatientGridCard.tsx
@@ -1,6 +1,5 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { Card } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import type { Patient } from "@/types/api";
 
 interface PatientGridCardProps {
@@ -10,15 +9,19 @@ interface PatientGridCardProps {
 
 export function PatientGridCard({ patient, onClick }: PatientGridCardProps) {
   const pressTimer = useRef<NodeJS.Timeout | null>(null);
+  const [isPressing, setIsPressing] = useState(false);
   const labsUrl = `http://115.241.194.20/LIS/Reports/Patient_Report.aspx?prno=${patient.mrn}`;
 
   const startPress = () => {
+    setIsPressing(true);
     pressTimer.current = setTimeout(() => {
+      setIsPressing(false);
       window.open(labsUrl, "_blank");
     }, 600);
   };
 
   const cancelPress = () => {
+    setIsPressing(false);
     if (pressTimer.current) {
       clearTimeout(pressTimer.current);
       pressTimer.current = null;
@@ -33,7 +36,7 @@ export function PatientGridCard({ patient, onClick }: PatientGridCardProps) {
       onMouseLeave={cancelPress}
       onTouchStart={startPress}
       onTouchEnd={cancelPress}
-      className="aspect-square p-2 hover:shadow-sm transition-shadow cursor-pointer"
+      className={`aspect-square p-2 hover:shadow-sm transition-all cursor-pointer ${isPressing ? "scale-95 ring-2 ring-primary" : ""}`}
     >
       <div className="flex h-full flex-col justify-between text-xs space-y-1">
         <div className="space-y-1">
@@ -48,16 +51,6 @@ export function PatientGridCard({ patient, onClick }: PatientGridCardProps) {
             </span>
           )}
         </div>
-        <Button
-          variant="secondary"
-          size="sm"
-          onClick={(e) => {
-            e.stopPropagation();
-            window.open(labsUrl, "_blank");
-          }}
-        >
-          Labs
-        </Button>
       </div>
     </Card>
   );


### PR DESCRIPTION
## Summary
- remove Labs button from grid cards and open labs via animated long-press
- enable swipe-left animation on patient cards revealing Labs action

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c0a9e54208333bd9d2d1bec7a8b29