### PR TITLE
Refactor auth handling and enable persistence

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,22 +23,23 @@ import EditMedication from "./pages/EditMedication";
 import NotFound from "./pages/NotFound";
 import Login from "./pages/Login";
 import AdminApprovalPage from "./pages/AdminApproval";
-import { useAuth } from "./hooks/use-firebase-auth";
+import { useAuth } from "./context/AuthContext";
 import { useApprovalCheck } from "./hooks/use-approval-check";
 import { Navigate, useLocation } from "react-router-dom";
-
 
 const queryClient = new QueryClient();
 
 function RequireAuth({ children }: { children: JSX.Element }) {
-  const user = useAuth();
+  const { user, loading } = useAuth();
   const location = useLocation();
+  if (loading) {
+    return null;
+  }
   if (!user) {
     return <Navigate to="/login" state={{ from: location }} replace />;
   }
   return children;
 }
-
 
 const App = () => {
   const checkingApproval = useApprovalCheck();

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,35 @@
+import { createContext, useContext, useEffect, useState, PropsWithChildren } from 'react';
+import { auth } from '../lib/firebase';
+import { User, onAuthStateChanged } from 'firebase/auth';
+
+interface AuthContextType {
+  user: User | null;
+  loading: boolean;
+}
+
+const AuthContext = createContext<AuthContextType>({ user: null, loading: true });
+
+export function AuthProvider({ children }: PropsWithChildren<{}>) {
+  const [user, setUser] = useState<User | null>(auth.currentUser);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, currentUser => {
+      setUser(currentUser);
+      setLoading(false);
+    });
+    return unsubscribe;
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, loading }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}
+
+export default AuthContext;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -11,7 +11,8 @@ const AuthContext = createContext<AuthContextType>({ user: null, loading: true }
 
 export function AuthProvider({ children }: PropsWithChildren<{}>) {
   const [user, setUser] = useState<User | null>(auth.currentUser);
-  const [loading, setLoading] = useState(true);
+  // If a user is already cached by Firebase, skip the initial loading state.
+  const [loading, setLoading] = useState(!auth.currentUser);
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, currentUser => {

--- a/src/hooks/use-approval-check.ts
+++ b/src/hooks/use-approval-check.ts
@@ -17,8 +17,13 @@ export function useApprovalCheck() {
             try {
                 if (user) {
                     try {
-                        const tokenResult = await user.getIdTokenResult();
-                        if (!tokenResult.claims.approved) {
+                        let token = await user.getIdToken();
+                        let { approved, exp } = JSON.parse(atob(token.split('.')[1]));
+                        if (exp * 1000 < Date.now() || approved === undefined) {
+                            token = await user.getIdToken(true);
+                            ({ approved } = JSON.parse(atob(token.split('.')[1])));
+                        }
+                        if (!approved) {
                             await logOut();
                             alert('Your account is pending approval by an admin.');
                         }

--- a/src/hooks/use-approval-check.ts
+++ b/src/hooks/use-approval-check.ts
@@ -1,17 +1,13 @@
 import { useEffect, useState } from 'react';
-import { useAuth, logOut } from './use-firebase-auth';
-import { getFirestore, doc, getDoc, setDoc } from 'firebase/firestore';
-import { app } from '../lib/firebase';
-
-const db = getFirestore(app);
+import { useAuth } from '../context/AuthContext';
+import { logOut } from './use-firebase-auth';
 
 /**
- * Hook to check if the current user is approved in Firestore.
+ * Hook to check if the current user has an approved custom claim.
  * If not approved, logs out and shows a pending message.
- * Also creates a user doc on first login if it doesn't exist.
  */
 export function useApprovalCheck() {
-    const user = useAuth();
+    const { user } = useAuth();
     const [checking, setChecking] = useState(false);
 
     useEffect(() => {
@@ -20,37 +16,15 @@ export function useApprovalCheck() {
             setChecking(true);
             try {
                 if (user) {
-                    const userRef = doc(db, 'userApprovals', user.uid);
-                    let userSnap;
                     try {
-                        userSnap = await getDoc(userRef);
+                        const tokenResult = await user.getIdTokenResult();
+                        if (!tokenResult.claims.approved) {
+                            await logOut();
+                            alert('Your account is pending approval by an admin.');
+                        }
                     } catch (err) {
-                        // Firestore read error
                         await logOut();
                         alert('There was a problem checking your approval status. Please contact support.');
-                        return;
-                    }
-                    if (!userSnap.exists()) {
-                        // Create user doc with approved: false, then log out
-                        try {
-                            await setDoc(userRef, {
-                                email: user.email,
-                                approved: false,
-                                createdAt: new Date().toISOString(),
-                            });
-                        } catch (err) {
-                            await logOut();
-                            alert('There was a problem creating your approval request. Please contact support.');
-                            return;
-                        }
-                        await logOut();
-                        alert('Your account is pending approval by an admin.');
-                        return;
-                    }
-                    if (!userSnap.data().approved) {
-                        await logOut();
-                        alert('Your account is pending approval by an admin.');
-                        return;
                     }
                 }
             } finally {

--- a/src/hooks/use-firebase-auth.ts
+++ b/src/hooks/use-firebase-auth.ts
@@ -1,26 +1,11 @@
-import { useState } from 'react';
 import { auth } from '../lib/firebase';
 import {
     createUserWithEmailAndPassword,
     signInWithEmailAndPassword,
     signOut,
-    User,
-    onAuthStateChanged,
     signInWithPopup,
     GoogleAuthProvider,
 } from 'firebase/auth';
-
-// Hook to get the current user
-export function useAuth() {
-    const [user, setUser] = useState<User | null>(auth.currentUser);
-
-    useState(() => {
-        const unsubscribe = onAuthStateChanged(auth, setUser);
-        return unsubscribe;
-    });
-
-    return user;
-}
 
 // Sign up with email and password
 export function signUp(email: string, password: string) {

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -2,7 +2,7 @@
 // Firebase initialization. Replace the config object with your Firebase project credentials.
 
 import { initializeApp } from 'firebase/app';
-import { getAuth } from 'firebase/auth';
+import { initializeAuth, indexedDBLocalPersistence } from 'firebase/auth';
 import { getFirestore, enableIndexedDbPersistence } from 'firebase/firestore';
 
 const firebaseConfig = {
@@ -16,7 +16,9 @@ const firebaseConfig = {
 };
 
 export const app = initializeApp(firebaseConfig);
-export const auth = getAuth(app);
+export const auth = initializeAuth(app, {
+    persistence: indexedDBLocalPersistence,
+});
 export const db = getFirestore(app);
 
 // Enable offline persistence for Firestore

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -3,6 +3,7 @@
 
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
+import { getFirestore, enableIndexedDbPersistence } from 'firebase/firestore';
 
 const firebaseConfig = {
     apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -14,6 +15,11 @@ const firebaseConfig = {
     measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
 };
 
-
 export const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
+export const db = getFirestore(app);
+
+// Enable offline persistence for Firestore
+enableIndexedDbPersistence(db).catch((err) => {
+    console.warn('Failed to enable persistence', err);
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,10 @@
-import { createRoot } from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import { createRoot } from 'react-dom/client';
+import App from './App.tsx';
+import './index.css';
+import { AuthProvider } from './context/AuthContext';
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <AuthProvider>
+    <App />
+  </AuthProvider>
+);

--- a/src/pages/AdminApproval.tsx
+++ b/src/pages/AdminApproval.tsx
@@ -1,12 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { getFirestore, collection, getDocs, updateDoc, doc, serverTimestamp } from 'firebase/firestore';
-import { app } from '../lib/firebase';
-import { useAuth } from '../hooks/use-firebase-auth';
-
-const db = getFirestore(app);
+import { collection, getDocs, updateDoc, doc, serverTimestamp } from 'firebase/firestore';
+import { db } from '../lib/firebase';
+import { useAuth } from '../context/AuthContext';
 
 const AdminApprovalPage: React.FC = () => {
-    const user = useAuth();
+    const { user } = useAuth();
     const [pendingUsers, setPendingUsers] = useState<any[]>([]);
     const [approvedUsers, setApprovedUsers] = useState<any[]>([]);
     const [deniedUsers, setDeniedUsers] = useState<any[]>([]);

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,11 +1,10 @@
-
 import React, { useState, useEffect } from 'react';
-import { useAuth, signIn, signUp, logOut, signInWithGoogle } from '../hooks/use-firebase-auth';
+import { signIn, signUp, logOut, signInWithGoogle } from '../hooks/use-firebase-auth';
+import { useAuth } from '../context/AuthContext';
 import { useNavigate, useLocation } from 'react-router-dom';
 
-
 const Login: React.FC = () => {
-    const user = useAuth();
+    const { user } = useAuth();
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
     const [isSignUp, setIsSignUp] = useState(false);
@@ -21,7 +20,6 @@ const Login: React.FC = () => {
             navigate(from, { replace: true });
         }
     }, [user, from, navigate]);
-
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();


### PR DESCRIPTION
## Summary
- centralize Firebase auth with an AuthProvider and context
- use ID token custom claims for approval instead of Firestore reads
- enable Firestore offline persistence and update imports

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot read properties of undefined (reading 'allowShortCircuit'))*

------
https://chatgpt.com/codex/tasks/task_e_68a29d4dde748333b55f97d927828892