### PR TITLE
feat: compress and upload images via presigned URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@tanstack/react-query": "^5.56.2",
         "@types/qrcode": "^1.5.5",
         "@vercel/speed-insights": "^1.2.0",
+        "browser-image-compression": "^2.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
@@ -3331,6 +3332,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip": "0.20201231.0"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.24.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
@@ -6547,6 +6557,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
       "license": "MIT"
     },
     "node_modules/vaul": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@tanstack/react-query": "^5.56.2",
     "@types/qrcode": "^1.5.5",
     "@vercel/speed-insights": "^1.2.0",
+    "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",

--- a/src/components/ui/image-upload.tsx
+++ b/src/components/ui/image-upload.tsx
@@ -1,0 +1,44 @@
+import * as React from "react"
+
+import { Button } from "@/components/ui/button"
+import { uploadImage } from "@/lib/image-upload"
+
+interface ImageUploadProps {
+  onUploaded?: (url: string) => void
+}
+
+function ImageUpload({ onUploaded }: ImageUploadProps) {
+  const inputRef = React.useRef<HTMLInputElement>(null)
+  const [isUploading, setIsUploading] = React.useState(false)
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setIsUploading(true)
+    try {
+      const url = await uploadImage(file)
+      onUploaded?.(url)
+    } finally {
+      setIsUploading(false)
+      if (inputRef.current) inputRef.current.value = ""
+    }
+  }
+
+  return (
+    <div>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        onChange={handleFileChange}
+        className="hidden"
+      />
+      <Button type="button" onClick={() => inputRef.current?.click()} disabled={isUploading}>
+        {isUploading ? "Uploading..." : "Upload Photo"}
+      </Button>
+    </div>
+  )
+}
+
+export { ImageUpload }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -143,6 +143,12 @@ export const api = {
         method: 'DELETE',
       }),
   },
+  uploads: {
+    getPresignedUrl: (fileName: string, fileType: string) =>
+      request<{ uploadUrl: string; fileUrl: string }>(
+        `/uploads/presigned?fileName=${encodeURIComponent(fileName)}&fileType=${encodeURIComponent(fileType)}`
+      ),
+  },
 };
 
 export default api;

--- a/src/lib/image-upload.ts
+++ b/src/lib/image-upload.ts
@@ -1,0 +1,25 @@
+import imageCompression from 'browser-image-compression';
+import api from './api';
+
+export async function uploadImage(file: File): Promise<string> {
+  const compressed = await imageCompression(file, {
+    maxSizeMB: 1,
+    maxWidthOrHeight: 1920,
+    useWebWorker: true,
+  });
+
+  const { uploadUrl, fileUrl } = await api.uploads.getPresignedUrl(
+    compressed.name,
+    compressed.type
+  );
+
+  await fetch(uploadUrl, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': compressed.type,
+    },
+    body: compressed,
+  });
+
+  return fileUrl;
+}


### PR DESCRIPTION
## Summary
- add browser-image-compression dependency
- provide API helper for presigned uploads
- create utility and component for compressing and uploading photos

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a39a5ac278833399e0f0a160757d3c