### PR TITLE
Harden discharge summary persistence and align patient state updates

### DIFF
--- a/backend/dev/HMSdevmrnchange/discharge.mjs
+++ b/backend/dev/HMSdevmrnchange/discharge.mjs
@@ -1,0 +1,392 @@
+// discharge.mjs — Versioned discharge summaries (Node 22 ESM)
+
+import {
+  DeleteCommand,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+  TransactWriteCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { resolveAnyPatientId } from "./ids.mjs";
+
+const STATUS = new Set(["draft", "published", "archived"]);
+
+const toUiDS = (it = {}) => ({
+  versionId: it.ds_id,
+  patientId: it.patient_uid,
+  status: it.status || "draft",
+  format: it.format || "mdx",
+  mdx: it.mdx || "",
+  sections: it.sections || {},
+  summary: it.summary || null,
+  mrn: it.mrn ?? null,
+  scheme: it.scheme ?? null,
+  authorId: it.author_id ?? null,
+  authorName: it.author_name ?? null,
+  commitMessage: it.commit_message ?? null,
+  createdAt: it.created_at,
+  updatedAt: it.updated_at,
+  deleted: !!it.deleted,
+});
+
+const newId = () => `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const encodeCursor = (key) => Buffer.from(JSON.stringify(key)).toString("base64");
+const decodeCursor = (str) => {
+  try { return JSON.parse(Buffer.from(str, "base64").toString("utf8")); } catch { return null; }
+};
+
+function sanitizeSections(raw) {
+  if (!raw || typeof raw !== "object") return {};
+  const out = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (value == null) continue;
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed) out[key] = trimmed;
+      continue;
+    }
+    if (typeof value === "object") {
+      const nested = {};
+      for (const [childKey, childValue] of Object.entries(value)) {
+        if (childValue == null) continue;
+        const normalized = typeof childValue === "string" ? childValue : String(childValue);
+        const trimmed = normalized.trim();
+        if (trimmed) nested[childKey] = trimmed;
+      }
+      if (Object.keys(nested).length) {
+        out[key] = nested;
+      }
+      continue;
+    }
+    const fallback = String(value).trim();
+    if (fallback) out[key] = fallback;
+  }
+  return out;
+}
+
+function sanitizeSummary(raw) {
+  if (!raw || typeof raw !== "object") return null;
+  const out = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (value == null) continue;
+    out[key] = typeof value === "string" ? value : String(value);
+  }
+  return Object.keys(out).length ? out : null;
+}
+
+function normalizeContent(body = {}) {
+  const mdx = typeof body.mdx === "string" ? body.mdx : "";
+  const sections = sanitizeSections(body.sections);
+  const summary = sanitizeSummary(body.summary);
+  const status = STATUS.has(body.status) ? body.status : "draft";
+  const commit = typeof body.commitMessage === "string" && body.commitMessage.trim()
+    ? body.commitMessage
+    : typeof body.commit === "string" && body.commit.trim() ? body.commit : null;
+  const authorId = typeof body.authorId === "string" && body.authorId.trim()
+    ? body.authorId.trim()
+    : typeof body.actorId === "string" && body.actorId.trim() ? body.actorId.trim() : "anon";
+  const authorName = typeof body.authorName === "string" && body.authorName.trim()
+    ? body.authorName.trim()
+    : null;
+  return { mdx, sections, summary, status, commit, authorId, authorName };
+}
+
+const sectionsHaveContent = (sections) => {
+  if (!sections) return false;
+  if (typeof sections === "string") return sections.trim().length > 0;
+  if (typeof sections !== "object") return String(sections).trim().length > 0;
+  return Object.values(sections).some((value) => {
+    if (!value) return false;
+    if (typeof value === "string") return value.trim().length > 0;
+    if (typeof value === "object") return sectionsHaveContent(value);
+    return String(value).trim().length > 0;
+  });
+};
+
+async function findVersionById(ddb, TABLE, uid, versionId) {
+  const q = await ddb.send(new QueryCommand({
+    TableName: TABLE,
+    KeyConditionExpression: "PK = :pk AND begins_with(SK, :sk)",
+    ExpressionAttributeValues: { ":pk": `PATIENT#${uid}`, ":sk": "DS#" },
+    ScanIndexForward: false,
+    Limit: 200,
+  }));
+  const hit = (q.Items || []).find((i) => i.ds_id === versionId && i.SK !== "DS#LATEST");
+  return hit || null;
+}
+
+export function mountDischargeRoutes(router, ctx) {
+  const { ddb, TABLE, utils } = ctx;
+  const { nowISO, resp, parseBody } = utils;
+
+  // GET /patients/:id/discharge
+  router.add("GET", /^\/?patients\/([^/]+)\/discharge\/?$/, async ({ match }) => {
+    const rawId = decodeURIComponent(match[1]);
+    const resolved = await resolveAnyPatientId(ddb, TABLE, rawId);
+    if (!resolved?.meta) return resp(404, { error: "Patient not found" });
+
+    const ptr = await ddb.send(new GetCommand({
+      TableName: TABLE,
+      Key: { PK: `PATIENT#${resolved.uid}`, SK: "DS#LATEST" },
+    }));
+
+    if (!ptr.Item) return resp(200, { latest: null, versions: 0 });
+    return resp(200, { latest: toUiDS(ptr.Item) });
+  });
+
+  // GET /patients/:id/discharge/versions
+  router.add("GET", /^\/?patients\/([^/]+)\/discharge\/versions\/?$/, async ({ match, qs }) => {
+    const rawId = decodeURIComponent(match[1]);
+    const resolved = await resolveAnyPatientId(ddb, TABLE, rawId);
+    if (!resolved?.meta) return resp(404, { error: "Patient not found" });
+
+    const limit = Math.min(Number(qs.limit || 50), 200);
+    const includeDeleted = qs.includeDeleted === "1";
+    const cursor = qs.cursor ? decodeCursor(qs.cursor) : null;
+
+    const q = await ddb.send(new QueryCommand({
+      TableName: TABLE,
+      KeyConditionExpression: "PK = :pk AND begins_with(SK, :sk)",
+      ExpressionAttributeValues: { ":pk": `PATIENT#${resolved.uid}`, ":sk": "DS#" },
+      ScanIndexForward: false,
+      Limit: limit,
+      ExclusiveStartKey: cursor || undefined,
+    }));
+
+    let items = q.Items || [];
+    items = items.filter((it) => it.SK !== "DS#LATEST");
+    if (!includeDeleted) items = items.filter((it) => !it.deleted);
+
+    return resp(200, {
+      items: items.map(toUiDS),
+      nextCursor: q.LastEvaluatedKey ? encodeCursor(q.LastEvaluatedKey) : null,
+    });
+  });
+
+  // GET /patients/:id/discharge/versions/:versionId
+  router.add("GET", /^\/?patients\/([^/]+)\/discharge\/versions\/([^/]+)\/?$/, async ({ match }) => {
+    const rawId = decodeURIComponent(match[1]);
+    const versionId = decodeURIComponent(match[2]);
+
+    const resolved = await resolveAnyPatientId(ddb, TABLE, rawId);
+    if (!resolved?.meta) return resp(404, { error: "Patient not found" });
+
+    const item = await findVersionById(ddb, TABLE, resolved.uid, versionId);
+    if (!item) return resp(404, { error: "Version not found" });
+
+    return resp(200, toUiDS(item));
+  });
+
+  // POST /patients/:id/discharge
+  router.add("POST", /^\/?patients\/([^/]+)\/discharge\/?$/, async ({ match, event }) => {
+    const rawId = decodeURIComponent(match[1]);
+    const body = parseBody(event) || {};
+
+    const resolved = await resolveAnyPatientId(ddb, TABLE, rawId);
+    if (!resolved?.meta) return resp(404, { error: "Patient not found" });
+
+    const now = nowISO();
+    const uid = resolved.uid;
+    const meta = resolved.meta;
+    const { mdx, sections, summary, status, commit, authorId, authorName } = normalizeContent(body);
+
+    const hasSections = sectionsHaveContent(sections);
+    if (!mdx && !hasSections) return resp(400, { error: "mdx or sections required" });
+
+    const dsId = newId();
+    const skVersion = `DS#${now}#${dsId}`;
+
+    const versionItem = {
+      PK: `PATIENT#${uid}`,
+      SK: skVersion,
+      ds_id: dsId,
+      patient_uid: uid,
+      status,
+      format: "mdx",
+      mdx,
+      sections: hasSections ? sections : {},
+      summary,
+      mrn: meta.active_reg_mrn || null,
+      scheme: meta.active_scheme || null,
+      author_id: authorId || null,
+      author_name: authorName || null,
+      commit_message: commit,
+      created_at: now,
+      updated_at: now,
+      deleted: false,
+    };
+
+    const latestItem = {
+      PK: `PATIENT#${uid}`,
+      SK: "DS#LATEST",
+      patient_uid: uid,
+      ds_current_sk: skVersion,
+      ds_current_id: dsId,
+      status,
+      title: "Discharge Summary",
+      mdx,
+      sections: hasSections ? sections : {},
+      summary,
+      mrn: versionItem.mrn,
+      scheme: versionItem.scheme,
+      author_id: authorId || null,
+      author_name: authorName || null,
+      created_at: versionItem.created_at,
+      updated_at: now,
+    };
+
+    await ddb.send(new TransactWriteCommand({
+      TransactItems: [
+        { Put: { TableName: TABLE, Item: versionItem } },
+        { Put: { TableName: TABLE, Item: latestItem } },
+        {
+          Update: {
+            TableName: TABLE,
+            Key: { PK: `PATIENT#${uid}`, SK: "META_LATEST" },
+            UpdateExpression: "ADD update_counter :one SET last_updated = :now",
+            ExpressionAttributeValues: { ":one": 1, ":now": now },
+          },
+        },
+      ],
+    }));
+
+    return resp(201, {
+      message: "created",
+      latest: toUiDS(latestItem),
+      version: toUiDS(versionItem),
+    });
+  });
+
+  // PATCH /patients/:id/discharge/versions/:versionId
+  router.add("PATCH", /^\/?patients\/([^/]+)\/discharge\/versions\/([^/]+)\/?$/, async ({ match, event }) => {
+    const rawId = decodeURIComponent(match[1]);
+    const versionId = decodeURIComponent(match[2]);
+    const body = parseBody(event) || {};
+
+    const resolved = await resolveAnyPatientId(ddb, TABLE, rawId);
+    if (!resolved?.meta) return resp(404, { error: "Patient not found" });
+
+    const item = await findVersionById(ddb, TABLE, resolved.uid, versionId);
+    if (!item) return resp(404, { error: "Version not found" });
+
+    const now = nowISO();
+    const names = {};
+    const values = { ":now": now };
+    let setExpr = "SET updated_at = :now";
+
+    if (body.status && STATUS.has(body.status)) {
+      names["#status"] = "status";
+      values[":status"] = body.status;
+      setExpr += ", #status = :status";
+    }
+    if (body.commitMessage) {
+      names["#commit"] = "commit_message";
+      values[":commit"] = body.commitMessage;
+      setExpr += ", #commit = :commit";
+    }
+
+    if (setExpr === "SET updated_at = :now") {
+      return resp(400, { error: "nothing to update" });
+    }
+
+    const upd = await ddb.send(new UpdateCommand({
+      TableName: TABLE,
+      Key: { PK: item.PK, SK: item.SK },
+      UpdateExpression: setExpr,
+      ExpressionAttributeNames: Object.keys(names).length ? names : undefined,
+      ExpressionAttributeValues: values,
+      ReturnValues: "ALL_NEW",
+    }));
+
+    const ptr = await ddb.send(new GetCommand({
+      TableName: TABLE,
+      Key: { PK: item.PK, SK: "DS#LATEST" },
+    }));
+
+    if (ptr.Item && ptr.Item.ds_current_sk === item.SK) {
+      const attrs = upd.Attributes || {};
+      await ddb.send(new UpdateCommand({
+        TableName: TABLE,
+        Key: { PK: item.PK, SK: "DS#LATEST" },
+        UpdateExpression: "SET #status = :status, updated_at = :now",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: { ":status": attrs.status, ":now": now },
+      }));
+    }
+
+    return resp(200, { message: "updated", version: toUiDS(upd.Attributes) });
+  });
+
+  // DELETE /patients/:id/discharge/versions/:versionId
+  router.add("DELETE", /^\/?patients\/([^/]+)\/discharge\/versions\/([^/]+)\/?$/, async ({ match }) => {
+    const rawId = decodeURIComponent(match[1]);
+    const versionId = decodeURIComponent(match[2]);
+
+    const resolved = await resolveAnyPatientId(ddb, TABLE, rawId);
+    if (!resolved?.meta) return resp(404, { error: "Patient not found" });
+
+    const item = await findVersionById(ddb, TABLE, resolved.uid, versionId);
+    if (!item) return resp(404, { error: "Version not found" });
+
+    const now = nowISO();
+    await ddb.send(new UpdateCommand({
+      TableName: TABLE,
+      Key: { PK: item.PK, SK: item.SK },
+      UpdateExpression: "SET deleted = :true, updated_at = :now",
+      ExpressionAttributeValues: { ":true": true, ":now": now },
+    }));
+
+    const ptr = await ddb.send(new GetCommand({
+      TableName: TABLE,
+      Key: { PK: item.PK, SK: "DS#LATEST" },
+    }));
+
+    if (ptr.Item && ptr.Item.ds_current_sk === item.SK) {
+      const q = await ddb.send(new QueryCommand({
+        TableName: TABLE,
+        KeyConditionExpression: "PK = :pk AND begins_with(SK, :sk)",
+        ExpressionAttributeValues: { ":pk": item.PK, ":sk": "DS#" },
+        ScanIndexForward: false,
+        Limit: 200,
+      }));
+
+      const next = (q.Items || []).find(
+        (candidate) => candidate.SK !== "DS#LATEST" && candidate.SK !== item.SK && !candidate.deleted,
+      );
+
+      if (next) {
+        const pointer = {
+          PK: item.PK,
+          SK: "DS#LATEST",
+          patient_uid: next.patient_uid,
+          ds_current_sk: next.SK,
+          ds_current_id: next.ds_id,
+          status: next.status || "draft",
+          title: "Discharge Summary",
+          mdx: next.mdx || "",
+          sections: sectionsHaveContent(next.sections) ? next.sections : {},
+          summary: next.summary || null,
+          mrn: next.mrn ?? null,
+          scheme: next.scheme ?? null,
+          author_id: next.author_id ?? null,
+          author_name: next.author_name ?? null,
+          created_at: next.created_at,
+          updated_at: now,
+        };
+
+        await ddb.send(new PutCommand({
+          TableName: TABLE,
+          Item: pointer,
+        }));
+      } else {
+        await ddb.send(new DeleteCommand({
+          TableName: TABLE,
+          Key: { PK: item.PK, SK: "DS#LATEST" },
+        }));
+      }
+    }
+
+    return resp(200, { message: "deleted" });
+  });
+}

--- a/backend/dev/HMSdevmrnchange/router.mjs
+++ b/backend/dev/HMSdevmrnchange/router.mjs
@@ -13,6 +13,7 @@ import { mountTimelineRoutes } from "./timeline.mjs";
 import { mountChecklistRoutes } from "./checklists.mjs";
 import { mountFileRoutes } from "./files.mjs";
 import { mountDocumentRoutes } from "./documents.mjs";
+import { mountDischargeRoutes } from "./discharge.mjs";
 
 /* ---- env & clients ---- */
 const REGION = process.env.AWS_REGION || "ap-south-1";
@@ -97,6 +98,7 @@ export const handler = async (event = {}) => {
   mountChecklistRoutes(router, ctx);
   mountFileRoutes(router, ctx);
   mountDocumentRoutes(router, ctx);
+  mountDischargeRoutes(router, ctx);
 
   try {
     const out = await router.handle(event);

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,8 @@
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
         "eslint-plugin-react-refresh": "^0.4.9",
         "globals": "^15.9.0",
+        "husky": "^9.0.10",
+        "lint-staged": "^15.2.4",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.11",
         "typescript": "^5.5.3",
@@ -3183,6 +3185,22 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.1.1.tgz",
+      "integrity": "sha512-Zhl0ErHcSRUaVfGUeUdDuLgpkEo8KIFjB4Y9uAc46ScOpdDiU1Dbyplh7qWJeJ/ZHpbyMSM26+X3BySgnIz40Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
@@ -3486,6 +3504,64 @@
       },
       "funding": {
         "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cliui": {
@@ -3959,6 +4035,13 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -4138,9 +4221,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4257,6 +4340,19 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -4504,6 +4600,30 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
     },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4723,6 +4843,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
+      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-nonce": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
@@ -4730,6 +4863,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/glob": {
@@ -4835,6 +4981,32 @@
       "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
       "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
       "license": "MIT"
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -4967,6 +5139,19 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -5079,6 +5264,138 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/lint-staged": {
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.2.tgz",
+      "integrity": "sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^13.1.0",
+        "debug": "^4.4.0",
+        "execa": "^8.0.1",
+        "lilconfig": "^3.1.3",
+        "listr2": "^8.2.5",
+        "micromatch": "^4.0.8",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.7.0"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/lint-staged/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz",
+      "integrity": "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^4.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -5120,6 +5437,115 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -5146,6 +5572,13 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5166,6 +5599,32 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -5284,6 +5743,35 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5300,6 +5788,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -5436,6 +5940,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/pify": {
@@ -5987,6 +6504,39 @@
         "node": ">=4"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -5996,6 +6546,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.24.0",
@@ -6117,6 +6674,49 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/sonner": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.5.0.tgz",
@@ -6134,6 +6734,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/string-width": {
@@ -6230,6 +6840,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-json-comments": {
@@ -6793,15 +7416,15 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
-      "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
       }
     },
     "node_modules/yargs": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import DocumentsRoot from "@/features/documents/pages/DocumentsRoot";
 import DocumentsFolder from "@/features/documents/pages/DocumentsFolder";
 import NoteDetail from "./pages/NoteDetail";
 import AddPatientPage from "./pages/AddPatientPage";
+import DischargeSummaryPage from "./pages/DischargeSummary";
 
 const queryClient = new QueryClient();
 
@@ -47,6 +48,7 @@ const App = () => (
           <Route path="/patients/:id/docs/:category" element={<DocumentsPage />} />
           {/* Legacy Documents route retained for compatibility */}
           <Route path="/patients/:id/documents" element={<DocumentsPage />} />
+          <Route path="/patients/:id/discharge-summary" element={<DischargeSummaryPage />} />
           <Route path="/patients/:id/edit" element={<EditPatient />} />
           <Route path="/patients/:id/add-note" element={<AddNote />} />
           <Route path="/patients/:id/notes/:noteId" element={<NoteDetail />} />

--- a/src/features/discharge-summary/DischargeSummaryForm.tsx
+++ b/src/features/discharge-summary/DischargeSummaryForm.tsx
@@ -1,0 +1,580 @@
+import { useCallback, useEffect, useMemo, useState, type ChangeEvent } from "react";
+import { Check, Loader2, Save } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/hooks/use-toast";
+import { cn } from "@/lib/utils";
+import api from "@/lib/api";
+import type { DischargeSummaryVersion } from "@/types/api";
+
+type FieldType = "text" | "textarea" | "date";
+
+type SectionFieldDefinition = {
+  key: string;
+  label: string;
+  type?: FieldType;
+  placeholder?: string;
+  rows?: number;
+};
+
+type SectionDefinition = {
+  key: "administrative" | "presentingComplaint" | "pastHistory" | "examination" | "localExam" | "systemicExam" | "impression";
+  shortLabel: string;
+  title: string;
+  description?: string;
+  fields: SectionFieldDefinition[];
+};
+
+const SECTION_DEFINITIONS: SectionDefinition[] = [
+  {
+    key: "administrative",
+    shortLabel: "Admin",
+    title: "Administrative Details",
+    description: "Admission, surgery, and discharge milestones.",
+    fields: [
+      { key: "ipNumber", label: "IP No.", type: "text", placeholder: "Hospital in-patient number" },
+      { key: "doa", label: "Date of Admission (DOA)", type: "date" },
+      { key: "dos", label: "Date of Surgery (DOS)", type: "date" },
+      { key: "dod", label: "Date of Discharge (DOD)", type: "date" },
+    ],
+  },
+  {
+    key: "presentingComplaint",
+    shortLabel: "Complaint",
+    title: "Presenting Complaint",
+    description: "Capture the patient's chief complaints and history of presenting illness.",
+    fields: [
+      {
+        key: "chiefComplaints",
+        label: "Chief Complaints",
+        type: "textarea",
+        rows: 4,
+        placeholder: "Key complaints at the time of admission",
+      },
+      {
+        key: "hopi",
+        label: "History of Present Illness (HOPI)",
+        type: "textarea",
+        rows: 4,
+        placeholder: "Chronological narrative of the illness progression",
+      },
+    ],
+  },
+  {
+    key: "pastHistory",
+    shortLabel: "History",
+    title: "Past and Personal History",
+    description: "Summarise relevant medical, personal, and family history.",
+    fields: [
+      {
+        key: "pastHistory",
+        label: "Past History",
+        type: "textarea",
+        rows: 4,
+        placeholder: "Significant medical or surgical history",
+      },
+      {
+        key: "personalHistory",
+        label: "Personal History",
+        type: "textarea",
+        rows: 3,
+        placeholder: "Lifestyle, habits, occupational exposure",
+      },
+      {
+        key: "familyHistory",
+        label: "Family History",
+        type: "textarea",
+        rows: 3,
+        placeholder: "Genetic or familial conditions of note",
+      },
+    ],
+  },
+  {
+    key: "examination",
+    shortLabel: "Clinical",
+    title: "Clinical Examination",
+    description: "Document general examination and current vitals.",
+    fields: [
+      {
+        key: "generalExamination",
+        label: "General Examination",
+        type: "textarea",
+        rows: 4,
+        placeholder: "General appearance, orientation, build, nourishment",
+      },
+      {
+        key: "generalFindings",
+        label: "General Physical Findings",
+        type: "textarea",
+        rows: 4,
+        placeholder: "Pallor, icterus, clubbing, edema, lymphadenopathy, etc.",
+      },
+      { key: "temperature", label: "Temperature", type: "text", placeholder: "e.g. 98.6 °F" },
+      { key: "pulse", label: "Pulse", type: "text", placeholder: "e.g. 78 bpm" },
+      { key: "respirationRate", label: "Respiration Rate", type: "text", placeholder: "e.g. 18 / min" },
+      { key: "bloodPressure", label: "Blood Pressure", type: "text", placeholder: "e.g. 120/80 mmHg" },
+      { key: "spo2", label: "SpO₂", type: "text", placeholder: "e.g. 98 % on RA" },
+    ],
+  },
+  {
+    key: "localExam",
+    shortLabel: "Local",
+    title: "Local Examination",
+    description: "Focused examination relevant to the presenting complaint.",
+    fields: [
+      { key: "inspection", label: "Inspection", type: "textarea", rows: 3, placeholder: "Inspection findings" },
+      { key: "palpation", label: "Palpation", type: "textarea", rows: 3, placeholder: "Palpation findings" },
+      { key: "percussion", label: "Percussion", type: "textarea", rows: 3, placeholder: "Percussion findings" },
+      { key: "auscultation", label: "Auscultation", type: "textarea", rows: 3, placeholder: "Auscultation findings" },
+      {
+        key: "perRectal",
+        label: "Per Rectal Examination",
+        type: "textarea",
+        rows: 3,
+        placeholder: "Per rectal examination findings",
+      },
+    ],
+  },
+  {
+    key: "systemicExam",
+    shortLabel: "Systemic",
+    title: "Systemic Examination",
+    description: "Summarise findings for each major system.",
+    fields: [
+      { key: "cvs", label: "Cardiovascular System (CVS)", type: "textarea", rows: 3, placeholder: "CVS findings" },
+      { key: "cns", label: "Central Nervous System (CNS)", type: "textarea", rows: 3, placeholder: "CNS findings" },
+      { key: "resp", label: "Respiratory System (RESP)", type: "textarea", rows: 3, placeholder: "Respiratory findings" },
+      { key: "pa", label: "Per Abdomen (P/A)", type: "textarea", rows: 3, placeholder: "Per abdomen findings" },
+    ],
+  },
+  {
+    key: "impression",
+    shortLabel: "Impression",
+    title: "Clinical Impression",
+    description: "Capture the working diagnosis and discharge advice.",
+    fields: [
+      {
+        key: "provisionalDiagnosis",
+        label: "Impression / Provisional Diagnosis",
+        type: "textarea",
+        rows: 4,
+        placeholder: "Final diagnosis or key impression at discharge",
+      },
+      {
+        key: "dischargePlan",
+        label: "Discharge Plan / Advice",
+        type: "textarea",
+        rows: 4,
+        placeholder: "Medications, follow-up, rehabilitation, and precautions",
+      },
+    ],
+  },
+];
+
+type SectionKey = SectionDefinition["key"];
+type SectionState = Record<SectionKey, Record<string, string>>;
+
+const SECTION_MAP: Record<SectionKey, SectionDefinition> = SECTION_DEFINITIONS.reduce(
+  (acc, section) => {
+    acc[section.key] = section;
+    return acc;
+  },
+  {} as Record<SectionKey, SectionDefinition>,
+);
+
+const buildEmptySectionState = (): SectionState => {
+  return SECTION_DEFINITIONS.reduce((acc, section) => {
+    const fields = section.fields.reduce<Record<string, string>>((fieldAcc, field) => {
+      fieldAcc[field.key] = "";
+      return fieldAcc;
+    }, {});
+    acc[section.key] = fields;
+    return acc;
+  }, {} as SectionState);
+};
+
+const adaptSections = (sections: DischargeSummaryVersion["sections"]): SectionState => {
+  const draft = buildEmptySectionState();
+  if (!sections || typeof sections !== "object") {
+    return draft;
+  }
+
+  for (const [sectionKey, sectionValue] of Object.entries(sections)) {
+    if (!(sectionKey in SECTION_MAP)) continue;
+    const sectionDefinition = SECTION_MAP[sectionKey as SectionKey];
+    const current = draft[sectionDefinition.key];
+    if (!current) continue;
+
+    if (sectionValue && typeof sectionValue === "object") {
+      for (const [fieldKey, fieldValue] of Object.entries(sectionValue as Record<string, unknown>)) {
+        if (typeof fieldValue === "string" && fieldKey in current) {
+          current[fieldKey] = fieldValue;
+        }
+      }
+      continue;
+    }
+
+    if (typeof sectionValue === "string" && sectionDefinition.fields.length > 0) {
+      const firstField = sectionDefinition.fields[0];
+      current[firstField.key] = sectionValue;
+    }
+  }
+
+  return draft;
+};
+
+const deriveSummary = (state: SectionState) => {
+  const diagnosis = state.impression?.provisionalDiagnosis?.trim() ?? "";
+  const dod = state.administrative?.dod?.trim() ?? "";
+  if (!diagnosis && !dod) return undefined;
+  return {
+    diagnosis: diagnosis || undefined,
+    dod: dod || undefined,
+  };
+};
+
+const formatDateTime = (value?: string | null) => {
+  if (!value) return "—";
+  try {
+    return new Date(value).toLocaleString();
+  } catch (error) {
+    return value;
+  }
+};
+
+export default function DischargeSummaryForm({ patientIdOrMrn }: { patientIdOrMrn: string }) {
+  const { toast } = useToast();
+  const [activeSection, setActiveSection] = useState<SectionKey>(SECTION_DEFINITIONS[0].key);
+  const [sectionState, setSectionState] = useState<SectionState>(() => buildEmptySectionState());
+  const [latest, setLatest] = useState<DischargeSummaryVersion | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [savingStatus, setSavingStatus] = useState<"draft" | "published" | null>(null);
+  const [authorId, setAuthorId] = useState<string>(() => {
+    if (typeof window === "undefined") return "anon";
+    return localStorage.getItem("dischargeAuthorId") || "anon";
+  });
+  const [authorName, setAuthorName] = useState<string>(() => {
+    if (typeof window === "undefined") return "";
+    return localStorage.getItem("dischargeAuthorName") || "";
+  });
+
+  const hasContent = useMemo(() => {
+    return SECTION_DEFINITIONS.some((section) =>
+      Object.values(sectionState[section.key] || {}).some((value) => value.trim().length > 0),
+    );
+  }, [sectionState]);
+
+  const persistAuthor = useCallback(
+    (id: string, name: string) => {
+      if (typeof window === "undefined") return;
+      localStorage.setItem("dischargeAuthorId", id || "anon");
+      localStorage.setItem("dischargeAuthorName", name || "");
+    },
+    [],
+  );
+
+  const applyVersion = useCallback(
+    (version: DischargeSummaryVersion | null) => {
+      if (!version) {
+        setLatest(null);
+        setSectionState(buildEmptySectionState());
+        return;
+      }
+      setLatest(version);
+      setSectionState(adaptSections(version.sections));
+      if (typeof version.authorId === "string" && version.authorId.trim()) {
+        setAuthorId(version.authorId);
+      }
+      if (typeof version.authorName === "string") {
+        setAuthorName(version.authorName);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadLatest = async () => {
+      setLoading(true);
+      try {
+        const response = await api.discharge.getLatest(patientIdOrMrn);
+        if (cancelled) return;
+        applyVersion(response?.latest ?? null);
+      } catch (error) {
+        if (cancelled) return;
+        if (error instanceof Error && /not\s+found/i.test(error.message)) {
+          applyVersion(null);
+        } else {
+          toast({
+            title: "Unable to load discharge summary",
+            description: error instanceof Error ? error.message : "Please try again shortly.",
+            variant: "destructive",
+          });
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    loadLatest();
+    return () => {
+      cancelled = true;
+    };
+  }, [applyVersion, patientIdOrMrn, toast]);
+
+  const handleFieldChange = useCallback((sectionKey: SectionKey, fieldKey: string, value: string) => {
+    setSectionState((prev) => ({
+      ...prev,
+      [sectionKey]: {
+        ...prev[sectionKey],
+        [fieldKey]: value,
+      },
+    }));
+  }, []);
+
+  const handleSave = useCallback(
+    async (nextStatus: "draft" | "published") => {
+      if (!hasContent) {
+        toast({
+          title: "Nothing to save",
+          description: "Fill at least one field before saving.",
+        });
+        return;
+      }
+
+      setSavingStatus(nextStatus);
+      const normalizedAuthorId = authorId.trim() || "anon";
+      const normalizedAuthorName = authorName.trim();
+
+      try {
+        persistAuthor(normalizedAuthorId, normalizedAuthorName);
+        const sectionsPayload = SECTION_DEFINITIONS.reduce<Record<string, Record<string, string>>>(
+          (acc, section) => {
+            acc[section.key] = { ...sectionState[section.key] };
+            return acc;
+          },
+          {},
+        );
+        const summaryPayload = deriveSummary(sectionState) ?? null;
+
+        const response = await api.discharge.create(patientIdOrMrn, {
+          status: nextStatus,
+          sections: sectionsPayload,
+          summary: summaryPayload,
+          authorId: normalizedAuthorId,
+          authorName: normalizedAuthorName,
+          commitMessage:
+            nextStatus === "published" ? "Publish discharge summary" : "Save discharge summary draft",
+        });
+
+        applyVersion(response.latest);
+        toast({
+          title: nextStatus === "published" ? "Discharge summary published" : "Draft saved",
+          description: "A new discharge version has been recorded.",
+        });
+      } catch (error) {
+        toast({
+          title: "Save failed",
+          description: error instanceof Error ? error.message : "Please try again.",
+          variant: "destructive",
+        });
+      } finally {
+        setSavingStatus(null);
+      }
+    },
+    [applyVersion, authorId, authorName, hasContent, patientIdOrMrn, persistAuthor, sectionState, toast],
+  );
+
+  const activeDefinition = SECTION_MAP[activeSection];
+  const isSaving = savingStatus !== null;
+  const lastUpdatedLabel = formatDateTime(latest?.updatedAt);
+  const currentStatus = latest?.status ?? "draft";
+
+  const renderField = (sectionKey: SectionKey, field: SectionFieldDefinition) => {
+    const value = sectionState[sectionKey]?.[field.key] ?? "";
+    const handleChange = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+      handleFieldChange(sectionKey, field.key, event.target.value);
+    const fieldId = `${sectionKey}-${field.key}`;
+
+    if ((field.type ?? "textarea") === "textarea") {
+      return (
+        <div key={field.key} className="space-y-1">
+          <label htmlFor={fieldId} className="text-sm font-medium text-foreground">
+            {field.label}
+          </label>
+          <Textarea
+            id={fieldId}
+            value={value}
+            onChange={handleChange}
+            placeholder={field.placeholder}
+            disabled={loading || isSaving}
+            rows={field.rows ?? 4}
+          />
+        </div>
+      );
+    }
+
+    const inputType = field.type === "date" ? "date" : "text";
+    return (
+      <div key={field.key} className="space-y-1">
+        <label htmlFor={fieldId} className="text-sm font-medium text-foreground">
+          {field.label}
+        </label>
+        <Input
+          id={fieldId}
+          value={value}
+          onChange={handleChange}
+          placeholder={field.placeholder}
+          disabled={loading || isSaving}
+          type={inputType}
+        />
+      </div>
+    );
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex flex-1 flex-col lg:flex-row">
+        <aside className="hidden w-full max-w-[220px] flex-shrink-0 border-r bg-white lg:flex lg:flex-col">
+          <div className="px-5 py-4 text-sm font-semibold text-foreground">Sections</div>
+          <nav className="flex flex-1 flex-col">
+            {SECTION_DEFINITIONS.map((section) => (
+              <button
+                key={section.key}
+                type="button"
+                onClick={() => setActiveSection(section.key)}
+                className={cn(
+                  "flex w-full items-center gap-2 border-l-4 px-5 py-3 text-left text-sm transition",
+                  activeSection === section.key
+                    ? "border-primary bg-primary/10 font-semibold text-primary"
+                    : "border-transparent text-muted-foreground hover:bg-muted",
+                )}
+              >
+                <span>{section.shortLabel}</span>
+              </button>
+            ))}
+          </nav>
+        </aside>
+
+        <div className="flex-1 overflow-y-auto">
+          <div className="border-b bg-white px-4 py-3 lg:hidden">
+            <label className="text-xs font-medium text-muted-foreground" htmlFor="discharge-section-select">
+              Section
+            </label>
+            <select
+              id="discharge-section-select"
+              className="mt-1 w-full rounded-md border px-3 py-2 text-sm"
+              value={activeSection}
+              onChange={(event) => setActiveSection(event.target.value as SectionKey)}
+              disabled={loading || isSaving}
+            >
+              {SECTION_DEFINITIONS.map((section) => (
+                <option key={section.key} value={section.key}>
+                  {section.title}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="space-y-6 px-4 py-6 sm:px-6 lg:px-8">
+            <div className="space-y-4 rounded-lg border bg-white p-4 shadow-sm sm:p-6">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <h1 className="text-lg font-semibold text-foreground sm:text-xl">Discharge Summary</h1>
+                  <p className="text-sm text-muted-foreground">
+                    Complete each clinical section to capture the patient's discharge narrative.
+                  </p>
+                </div>
+                <Badge variant={currentStatus === "published" ? "default" : "outline"} className="uppercase">
+                  {currentStatus}
+                </Badge>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-1">
+                  <label htmlFor="author-id" className="text-xs font-medium uppercase text-muted-foreground">
+                    Author ID
+                  </label>
+                  <Input
+                    id="author-id"
+                    value={authorId}
+                    onChange={(event) => setAuthorId(event.target.value)}
+                    placeholder="e.g. staff001"
+                    disabled={loading || isSaving}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label htmlFor="author-name" className="text-xs font-medium uppercase text-muted-foreground">
+                    Author Name
+                  </label>
+                  <Input
+                    id="author-name"
+                    value={authorName}
+                    onChange={(event) => setAuthorName(event.target.value)}
+                    placeholder="Display name (optional)"
+                    disabled={loading || isSaving}
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-4 rounded-lg border bg-white p-4 shadow-sm sm:p-6">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <h2 className="text-base font-semibold text-foreground sm:text-lg">{activeDefinition.title}</h2>
+                  {activeDefinition.description ? (
+                    <p className="text-sm text-muted-foreground">{activeDefinition.description}</p>
+                  ) : null}
+                </div>
+                <div className="text-xs text-muted-foreground">{activeDefinition.shortLabel}</div>
+              </div>
+              <div className="grid gap-4">
+                {activeDefinition.fields.map((field) => renderField(activeDefinition.key, field))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="sticky bottom-0 z-10 border-t bg-background/95 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="text-sm text-muted-foreground">
+            Last updated: <span className="font-medium text-foreground">{lastUpdatedLabel}</span>
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <Button
+              variant="outline"
+              disabled={!hasContent || isSaving}
+              onClick={() => handleSave("draft")}
+              className="w-full sm:w-auto"
+            >
+              {isSaving && savingStatus === "draft" ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Save className="mr-2 h-4 w-4" />
+              )}
+              Save draft
+            </Button>
+            <Button
+              disabled={!hasContent || isSaving}
+              onClick={() => handleSave("published")}
+              className="w-full sm:w-auto"
+            >
+              {isSaving && savingStatus === "published" ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Check className="mr-2 h-4 w-4" />
+              )}
+              Publish
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/DischargeSummary.tsx
+++ b/src/pages/DischargeSummary.tsx
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Header } from "@/components/layout/Header";
+import { BottomBar } from "@/components/layout/BottomBar";
+import DischargeSummaryForm from "@/features/discharge-summary/DischargeSummaryForm";
+
+export default function DischargeSummaryPage() {
+  const navigate = useNavigate();
+  const { id } = useParams();
+
+  useEffect(() => {
+    document.title = "Discharge Summary | Clinical Canvas";
+  }, []);
+
+  if (!id) {
+    return (
+      <div className="min-h-screen bg-background">
+        <Header title="Discharge Summary" showBack onBack={() => navigate(-1)} />
+        <main className="flex min-h-[60vh] items-center justify-center p-6 text-sm text-muted-foreground">
+          Patient identifier is missing from the URL.
+        </main>
+        <BottomBar />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <Header title="Discharge Summary" showBack onBack={() => navigate(-1)} />
+      <main className="flex-1 overflow-hidden">
+        <DischargeSummaryForm patientIdOrMrn={id} />
+      </main>
+      <BottomBar />
+    </div>
+  );
+}

--- a/src/pages/PatientDetail.tsx
+++ b/src/pages/PatientDetail.tsx
@@ -9,7 +9,7 @@ import { PatientNotes } from "@/components/patient/PatientNotes";
 import { PatientMeds } from "@/components/patient/PatientMeds";
 import { Timeline } from "@/components/patient/Timeline";
 import { LabsOverviewCard } from "@/components/patient/LabsOverviewCard";
-import { ListTodo, FileText, Pill, MoreVertical, ChevronDown, FolderOpen, Copy, Plus } from "lucide-react";
+import { ListTodo, FileText, Pill, MoreVertical, ChevronDown, FolderOpen, Copy, Plus, ClipboardList } from "lucide-react";
 import { toast } from "@/components/ui/sonner";
 import {
   Dialog,
@@ -180,8 +180,10 @@ export default function PatientDetail() {
   const handleStageChange = async () => {
     if (!selectedStage || !id) return;
     try {
-      await api.patients.update(id, { currentState: selectedStage });
-      if (patient) {
+      const res = await api.patients.state(id, { current_state: selectedStage });
+      if (res?.patient) {
+        setPatient(res.patient);
+      } else if (patient) {
         setPatient({ ...patient, currentState: selectedStage });
       }
       setShowStageDialog(false);
@@ -582,6 +584,12 @@ export default function PatientDetail() {
             label: "Add medication",
             Icon: Pill,
             onClick: () => navigate(`/patients/${id}/add-med`),
+          },
+          {
+            key: "discharge",
+            label: "Discharge summary",
+            Icon: ClipboardList,
+            onClick: () => navigate(`/patients/${id}/discharge-summary`),
           },
         ]}
       />

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -124,3 +124,21 @@ export interface TimelineEntry {
   createdAt: string;
   updatedAt: string;
 }
+
+export interface DischargeSummaryVersion {
+  versionId?: string;
+  patientId?: string;
+  status: 'draft' | 'published' | 'archived';
+  format?: string;
+  mdx?: string;
+  sections?: Record<string, string | Record<string, string>>;
+  summary?: { diagnosis?: string; dod?: string } | null;
+  mrn?: string | null;
+  scheme?: string | null;
+  authorId?: string | null;
+  authorName?: string | null;
+  commitMessage?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+  deleted?: boolean;
+}


### PR DESCRIPTION
## Summary
- trim and drop empty discharge summary section values before persisting so only meaningful content is stored
- require real content before creating a version and ensure stored records reuse the sanitised payloads
- retarget the DS#LATEST pointer when a version is soft deleted so the latest snapshot stays accurate
- mirror snake_case discharge and episode fields in the client payload so backend persistence keeps assigned doctor and urgency data
- switch patient stage changes to the dedicated /state endpoint so timeline and checklist workflows stay in sync

## Testing
- npm run build *(emits pre-existing duplicate key warnings in PatientRegistrationForm.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ebebcf936c8333b99315604c0d3cfa