### PR TITLE
Highlight discharge summary in patient notes

### DIFF
--- a/src/components/patient/PatientNotes.tsx
+++ b/src/components/patient/PatientNotes.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo } from "react";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import type { Note } from "@/types/api";
+import type { DischargeSummaryVersion, Note } from "@/types/api";
 import api from "@/lib/api";
 import { useNavigate } from "react-router-dom";
 import {
@@ -12,7 +12,9 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { listFiles } from "@/lib/filesApi";
-import { MoreVertical, Image as ImageIcon, FileText } from "lucide-react";
+import { MoreVertical, Image as ImageIcon, FileText, ChevronDown } from "lucide-react";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { SECTION_DEFINITIONS, adaptSections } from "@/features/discharge-summary/discharge.sections";
 
 interface PatientNotesProps {
   patientId: string;
@@ -26,28 +28,79 @@ function badgeTone(label?: string) {
   return "bg-muted text-foreground";
 }
 
+function formatDateTime(value?: string | null) {
+  if (!value) return null;
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return value;
+    return date.toLocaleString();
+  } catch {
+    return value;
+  }
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return null;
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return value;
+    return date.toLocaleDateString();
+  } catch {
+    return value;
+  }
+}
+
 export function PatientNotes({ patientId }: PatientNotesProps) {
   const [notes, setNotes] = useState<Note[]>([]);
   const [previews, setPreviews] = useState<Record<string, { urls: string[]; total: number }>>({});
   const [filter, setFilter] = useState<"all" | Note["category"]>("all");
-  const [loading, setLoading] = useState(true);
+  const [notesLoading, setNotesLoading] = useState(true);
+  const [dischargeSummary, setDischargeSummary] = useState<DischargeSummaryVersion | null>(null);
+  const [dischargeLoading, setDischargeLoading] = useState(true);
+  const [dischargeError, setDischargeError] = useState<string | null>(null);
+  const [dischargeExpanded, setDischargeExpanded] = useState(false);
   const navigate = useNavigate();
 
   useEffect(() => {
     let mounted = true;
     (async () => {
-      setLoading(true);
+      setNotesLoading(true);
       try {
         const res = await api.notes.list(patientId, 50);
         if (mounted) setNotes(res.items || []);
       } catch {
         if (mounted) setNotes([]);
       } finally {
-        if (mounted) setLoading(false);
+        if (mounted) setNotesLoading(false);
       }
     })();
     return () => {
       mounted = false;
+    };
+  }, [patientId]);
+
+  useEffect(() => {
+    let canceled = false;
+    setDischargeLoading(true);
+    setDischargeError(null);
+    (async () => {
+      try {
+        const res = await api.discharge.getLatest(patientId);
+        if (!canceled) {
+          setDischargeSummary(res.latest ?? null);
+          setDischargeError(null);
+        }
+      } catch (error) {
+        if (!canceled) {
+          setDischargeSummary(null);
+          setDischargeError(error instanceof Error ? error.message : "Unable to load discharge summary.");
+        }
+      } finally {
+        if (!canceled) setDischargeLoading(false);
+      }
+    })();
+    return () => {
+      canceled = true;
     };
   }, [patientId]);
 
@@ -84,12 +137,55 @@ export function PatientNotes({ patientId }: PatientNotesProps) {
     };
   }, [notes, patientId]);
 
-  const filtered = useMemo(
-    () => (filter === "all" ? notes : notes.filter((n) => n.category === filter)),
-    [filter, notes]
-  );
+  useEffect(() => {
+    if (!dischargeSummary) setDischargeExpanded(false);
+  }, [dischargeSummary]);
 
-  if (loading) return <div className="text-sm text-muted-foreground">Loading…</div>;
+  const dischargeSections = useMemo(() => {
+    if (!dischargeSummary) return null;
+    return adaptSections(dischargeSummary.sections);
+  }, [dischargeSummary]);
+
+  const dischargePreview = useMemo(() => {
+    if (!dischargeSummary) return "No discharge summary recorded.";
+    const candidates = [
+      dischargeSummary.summary?.diagnosis?.trim(),
+      dischargeSections?.impression?.provisionalDiagnosis?.trim(),
+      dischargeSections?.impression?.dischargePlan?.trim(),
+      dischargeSections?.presentingComplaint?.chiefComplaints?.trim(),
+    ].filter((value): value is string => Boolean(value));
+    return candidates[0] || "No discharge summary recorded.";
+  }, [dischargeSummary, dischargeSections]);
+
+  const hasDischargeContent = useMemo(() => {
+    if (!dischargeSections) return false;
+    return SECTION_DEFINITIONS.some((section) =>
+      section.fields.some((field) =>
+        Boolean(dischargeSections[section.key]?.[field.key]?.trim())
+      )
+    );
+  }, [dischargeSections]);
+
+  const filtered = useMemo(() => {
+    if (filter === "all") return notes;
+    if (filter === "discharge") return [];
+    return notes.filter((n) => n.category === filter);
+  }, [filter, notes]);
+
+  const shouldRenderDischargeSection =
+    filter === "discharge" || Boolean(dischargeSummary) || dischargeLoading || Boolean(dischargeError);
+
+  const emptyMessage = (() => {
+    if (filter === "discharge") {
+      return "No discharge summary recorded for this patient.";
+    }
+    if (filter === "doctorNote") return "No doctor notes for this patient.";
+    if (filter === "nurseNote") return "No nurse notes for this patient.";
+    if (filter === "pharmacy") return "No pharmacy notes for this patient.";
+    return dischargeSummary
+      ? "No additional clinical notes for this patient."
+      : "No clinical notes for this patient.";
+  })();
 
   return (
     <div className="space-y-3">
@@ -109,11 +205,139 @@ export function PatientNotes({ patientId }: PatientNotesProps) {
         </DropdownMenu>
       </div>
 
-      {filtered.length === 0 ? (
+      {shouldRenderDischargeSection && (
+        dischargeSummary ? (
+          <Collapsible open={dischargeExpanded} onOpenChange={setDischargeExpanded}>
+            <Card className="bg-white p-4 rounded-lg shadow-sm">
+              <div className="flex items-start justify-between gap-3">
+                <CollapsibleTrigger asChild>
+                  <button className="flex flex-1 items-start justify-between gap-3 text-left">
+                    <div className="flex-1 space-y-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Badge
+                          variant="secondary"
+                          className={`text-xs font-semibold px-2.5 py-0.5 rounded-full ${badgeTone("discharge")}`}
+                        >
+                          Discharge Summary
+                        </Badge>
+                        {dischargeSummary.status && (
+                          <Badge variant="outline" className="text-xs font-medium capitalize">
+                            {dischargeSummary.status}
+                          </Badge>
+                        )}
+                        {dischargeSummary.updatedAt && (
+                          <span className="text-xs text-gray-500">
+                            Updated {formatDateTime(dischargeSummary.updatedAt)}
+                          </span>
+                        )}
+                        {dischargeSummary.summary?.dod && (
+                          <span className="text-xs text-gray-500">
+                            DOD: {formatDate(dischargeSummary.summary.dod)}
+                          </span>
+                        )}
+                      </div>
+                      <p className={`text-sm text-gray-800 ${dischargeExpanded ? "" : "line-clamp-2"}`}>
+                        {dischargePreview}
+                      </p>
+                      {(dischargeSummary.authorName || dischargeSummary.authorId) && (
+                        <p className="text-xs text-gray-500">
+                          Author: {dischargeSummary.authorName || dischargeSummary.authorId}
+                        </p>
+                      )}
+                    </div>
+                    <ChevronDown
+                      className={`h-5 w-5 flex-shrink-0 text-gray-500 transition-transform duration-200 ${
+                        dischargeExpanded ? "rotate-180" : ""
+                      }`}
+                    />
+                  </button>
+                </CollapsibleTrigger>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    event.preventDefault();
+                    navigate(`/patients/${patientId}/discharge-summary`);
+                  }}
+                >
+                  Edit
+                </Button>
+              </div>
+              <CollapsibleContent className="pt-3">
+                {hasDischargeContent ? (
+                  <div className="space-y-4">
+                    {SECTION_DEFINITIONS.map((section) => {
+                      const sectionState = dischargeSections?.[section.key];
+                      const populatedFields = section.fields.filter((field) =>
+                        Boolean(sectionState?.[field.key]?.trim())
+                      );
+                      if (!populatedFields.length) return null;
+                      return (
+                        <div key={section.key} className="space-y-2">
+                          <h5 className="text-sm font-semibold text-gray-700">{section.title}</h5>
+                          <dl className="space-y-2 rounded-md border border-muted/40 bg-muted/20 p-3">
+                            {populatedFields.map((field) => (
+                              <div key={field.key} className="space-y-0.5">
+                                <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                  {field.label}
+                                </dt>
+                                <dd className="text-sm text-gray-800 whitespace-pre-wrap">
+                                  {sectionState?.[field.key]}
+                                </dd>
+                              </div>
+                            ))}
+                          </dl>
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    No structured discharge summary content captured yet.
+                  </p>
+                )}
+              </CollapsibleContent>
+            </Card>
+          </Collapsible>
+        ) : (
+          <Card className="bg-white p-4 rounded-lg shadow-sm">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+              <div className="space-y-1">
+                <p className="text-sm font-semibold text-gray-800">Discharge Summary</p>
+                <p className="text-sm text-muted-foreground">
+                  {dischargeLoading
+                    ? "Loading discharge summary…"
+                    : dischargeError || "No discharge summary recorded for this patient."}
+                </p>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => navigate(`/patients/${patientId}/discharge-summary`)}
+              >
+                {dischargeLoading ? "View" : "Open"}
+              </Button>
+            </div>
+          </Card>
+        )
+      )}
+
+      {filter === "discharge" && dischargeSummary && (
+        <p className="text-xs text-muted-foreground">The discharge summary is displayed above.</p>
+      )}
+
+      {filter !== "discharge" && notesLoading && (
+        <div className="text-sm text-muted-foreground">Loading notes…</div>
+      )}
+
+      {filter !== "discharge" && !notesLoading && filtered.length === 0 && (
         <div className="text-center py-6 text-muted-foreground text-sm bg-muted/30 rounded-lg border border-dashed">
-          No clinical notes for this patient
+          {emptyMessage}
         </div>
-      ) : (
+      )}
+
+      {!notesLoading && filter !== "discharge" && filtered.length > 0 &&
         filtered.map((note) => {
           const pv = previews[note.noteId] || { urls: [], total: 0 };
           const count = pv.total || pv.urls.length;


### PR DESCRIPTION
## Summary
- surface the patient's discharge summary from the backend at the top of the notes tab with a collapsible preview, structured detail view, and edit shortcut
- keep the discharge summary out of the remaining notes list and clarify messaging when there are no additional notes

## Testing
- npm run lint *(fails: missing @eslint/js dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ec7cf6ad1c833384a089ae93029290