### PR TITLE
feat: add local backend development with LocalStack

### DIFF
--- a/Docs/backend/backend-architecture.md
+++ b/Docs/backend/backend-architecture.md
@@ -65,6 +65,7 @@ The backend exposes a Lambda Function URL (not API Gateway) with full CORS suppo
 |--------|------|-------------|
 | GET | `/patients` | List active patients (?department=) |
 | GET | `/patients/:id` | Get patient by UID or MRN |
+| GET | `/patients/by-mrn/:mrn` | Get patient by MRN (explicit lookup) |
 | POST | `/patients` | Create patient |
 | PUT | `/patients/:id` | Update patient fields |
 | DELETE | `/patients/:id` | Soft delete (set INACTIVE) |
@@ -72,6 +73,7 @@ The backend exposes a Lambda Function URL (not API Gateway) with full CORS suppo
 | PATCH | `/patients/:id/registration` | Switch MRN/scheme |
 | PATCH | `/patients/:id/mrn-history` | Rewrite MRN history |
 | PATCH | `/patients/:id/mrn-overwrite` | Replace history + switch active MRN |
+| POST | `/patients/janitor/mrn-history-normalize` | Maintenance: normalize mrn_history on all patients |
 
 ### Tasks
 | Method | Path | Description |
@@ -80,6 +82,8 @@ The backend exposes a Lambda Function URL (not API Gateway) with full CORS suppo
 | POST | `/patients/:id/tasks` | Create task |
 | PATCH | `/patients/:id/tasks/:taskId` | Update task |
 | DELETE | `/patients/:id/tasks/:taskId` | Soft cancel task |
+| POST | `/patients/:id/tasks/:taskId/files/attach` | Attach file to task |
+| POST | `/patients/:id/tasks/:taskId/files/detach` | Detach file from task |
 | GET | `/tasks` | Dashboard: tasks by dept/status (?department=&status=) |
 
 ### Notes
@@ -99,6 +103,8 @@ The backend exposes a Lambda Function URL (not API Gateway) with full CORS suppo
 | POST | `/patients/:id/meds` | Create medication |
 | PATCH | `/patients/:id/meds/:medId` | Update medication |
 | DELETE | `/patients/:id/meds/:medId` | Soft stop (set end date) |
+| POST | `/patients/:id/meds/:medId/files/attach` | Attach file to medication |
+| POST | `/patients/:id/meds/:medId/files/detach` | Detach file from medication |
 
 ### Doctors
 | Method | Path | Description |
@@ -206,16 +212,29 @@ Document types: `preop`, `lab`, `radiology`, `intraop`, `otnotes`, `postop`, `di
 
 ## Environment Variables
 
+### Primary
+
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `AWS_REGION` | `ap-south-1` | AWS region |
+| `AWS_REGION` | `ap-south-1` | AWS region for DynamoDB and S3 |
 | `TABLE_NAME` | `HMS` | DynamoDB table name |
 | `FILES_BUCKET` | — | S3 bucket for patient files |
 | `PRESIGN_EXPIRES_SEC` | `900` | Presigned URL expiry (seconds) |
 | `CDN_DOMAIN` | — | CloudFront distribution domain |
-| `CF_DISTRIBUTION_ID` | — | CloudFront distribution ID |
-| `CDN_SIGNED` | `false` | Use signed CloudFront URLs |
-| `AWS_ENDPOINT` | — | Custom endpoint (for LocalStack) |
+| `CF_DISTRIBUTION_ID` | — | CloudFront distribution ID (for cache invalidation) |
+| `AWS_ENDPOINT` | — | Custom AWS endpoint (for LocalStack local development) |
+
+### Fallback Variables
+
+These are checked as fallbacks in `files.mjs` for backward compatibility:
+
+| Variable | Fallback for | Used in |
+|----------|-------------|---------|
+| `S3_REGION` | `AWS_REGION` | `files.mjs` |
+| `DOCS_BUCKET` | `FILES_BUCKET` | `files.mjs` |
+| `S3_BUCKET` | `FILES_BUCKET` | `files.mjs` |
+| `S3_PRESIGN_EXPIRES` | `PRESIGN_EXPIRES_SEC` | `files.mjs` |
+| `CF_DOMAIN` | `CDN_DOMAIN` | `files.mjs`, `documents.mjs` |
 
 ---
 

--- a/Docs/backend/backend-architecture.md
+++ b/Docs/backend/backend-architecture.md
@@ -1,0 +1,224 @@
+# HMS Backend Architecture
+
+## Overview
+
+The HMS (Hospital Management System) backend is a **serverless** application deployed on AWS using:
+- **AWS Lambda** (Node.js 22.x ESM) — single function handling all API routes
+- **DynamoDB** — single-table design with GSIs for multi-access patterns
+- **S3** — patient file storage with presigned URL uploads
+- **CloudFront** — CDN for serving patient files
+- **SAM/CloudFormation** — infrastructure-as-code deployment
+
+The backend exposes a Lambda Function URL (not API Gateway) with full CORS support.
+
+---
+
+## Architecture Diagram
+
+```
+┌─────────────┐     ┌───────────────────┐     ┌──────────────┐
+│   Frontend   │────▶│  Lambda Function  │────▶│  DynamoDB    │
+│  (React/Vite)│     │  URL (router.mjs) │     │  (HMS-HYD)   │
+└─────────────┘     └───────┬───────────┘     └──────────────┘
+                            │
+                    ┌───────▼───────────┐     ┌──────────────┐
+                    │   S3 (Patient     │────▶│  CloudFront  │
+                    │   Files Bucket)   │     │  (CDN)       │
+                    └───────────────────┘     └──────────────┘
+```
+
+## Lambda Handler Flow
+
+1. HTTP request arrives at Lambda Function URL
+2. `index.mjs` re-exports the handler from `router.mjs`
+3. CORS preflight (OPTIONS) returns 204 immediately
+4. Router creates shared `ctx` with DynamoDB client, table name, indexes, and utilities
+5. Feature modules mount their routes onto the router
+6. Router matches request path/method against registered regex patterns
+7. First matching route handler executes and returns response
+
+## Module Organization
+
+| Module | File | Purpose |
+|--------|------|---------|
+| Entry point | `index.mjs` | Re-exports handler from router |
+| Router | `router.mjs` | DDB client, CORS, routing, shared utils |
+| Patients | `patients.mjs` | Patient CRUD, state transitions, MRN management |
+| Doctors | `doctors.mjs` | Doctor profiles, department listing |
+| Tasks | `tasks.mjs` | Task CRUD, department dashboard via GSI2 |
+| Notes | `notes.mjs` | Clinical notes CRUD with file attachments |
+| Medications | `meds.mjs` | Medication CRUD with soft-stop deletion |
+| Timeline | `timeline.mjs` | Read-only patient state timeline |
+| Documents | `documents.mjs` | Per-category document registry |
+| Files | `files.mjs` | S3 presigned URLs, file listing, deletion |
+| Discharge | `discharge.mjs` | Versioned discharge summaries |
+| Checklists | `checklists.mjs` | Placeholder (not yet implemented) |
+| ID Resolution | `ids.mjs` | Resolve patient UID or MRN to canonical ID |
+| S3 Events | `s3_events.mjs` | Separate Lambda: S3 upload → DynamoDB sync |
+
+---
+
+## API Endpoints
+
+### Patients
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/patients` | List active patients (?department=) |
+| GET | `/patients/:id` | Get patient by UID or MRN |
+| POST | `/patients` | Create patient |
+| PUT | `/patients/:id` | Update patient fields |
+| DELETE | `/patients/:id` | Soft delete (set INACTIVE) |
+| PATCH | `/patients/:id/state` | Transition patient state |
+| PATCH | `/patients/:id/registration` | Switch MRN/scheme |
+| PATCH | `/patients/:id/mrn-history` | Rewrite MRN history |
+| PATCH | `/patients/:id/mrn-overwrite` | Replace history + switch active MRN |
+
+### Tasks
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/patients/:id/tasks` | List patient tasks (?status=&limit=) |
+| POST | `/patients/:id/tasks` | Create task |
+| PATCH | `/patients/:id/tasks/:taskId` | Update task |
+| DELETE | `/patients/:id/tasks/:taskId` | Soft cancel task |
+| GET | `/tasks` | Dashboard: tasks by dept/status (?department=&status=) |
+
+### Notes
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/patients/:id/notes` | List notes (paginated) |
+| POST | `/patients/:id/notes` | Create note |
+| PATCH | `/patients/:id/notes/:noteId` | Update note |
+| DELETE | `/patients/:id/notes/:noteId` | Soft delete note |
+| POST | `/patients/:id/notes/:noteId/files/attach` | Attach file to note |
+| POST | `/patients/:id/notes/:noteId/files/detach` | Detach file from note |
+
+### Medications
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/patients/:id/meds` | List medications (paginated) |
+| POST | `/patients/:id/meds` | Create medication |
+| PATCH | `/patients/:id/meds/:medId` | Update medication |
+| DELETE | `/patients/:id/meds/:medId` | Soft stop (set end date) |
+
+### Doctors
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/doctors` | List doctors (?department= required) |
+| GET | `/doctors/:doctorId` | Get doctor |
+| POST | `/doctors` | Create doctor |
+| PATCH | `/doctors/:doctorId` | Update doctor |
+| DELETE | `/doctors/:doctorId` | Soft delete doctor |
+
+### Timeline
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/patients/:id/timeline` | List timeline events |
+
+### Documents
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/patients/:id/documents` | Get documents profile |
+| POST | `/patients/:id/documents/init` | Initialize documents (idempotent) |
+| POST | `/patients/:id/documents/attach` | Attach file to category |
+| POST | `/patients/:id/documents/detach` | Detach file from category |
+| PATCH | `/patients/:id/documents/gov-share` | Set government sharing flag |
+
+### Files (S3)
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/patients/:id/files/presign-upload` | Get presigned upload URL |
+| GET | `/patients/:id/files` | List S3 files (?scope=&kind=&docType=) |
+| POST | `/patients/:id/files/presign-download` | Get presigned download URL |
+| POST | `/patients/:id/files/delete` | Delete S3 files |
+
+### Discharge
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/patients/:id/discharge` | Get latest discharge summary |
+| GET | `/patients/:id/discharge/versions` | List versions (paginated) |
+| GET | `/patients/:id/discharge/versions/:versionId` | Get specific version |
+| POST | `/patients/:id/discharge` | Create discharge version |
+| PATCH | `/patients/:id/discharge/versions/:versionId` | Update version status |
+| DELETE | `/patients/:id/discharge/versions/:versionId` | Soft delete version |
+
+---
+
+## DynamoDB Single-Table Design
+
+### Table: HMS-HYD
+
+**Primary Key:** PK (String) + SK (String)
+
+### Entity Key Patterns
+
+| Entity | PK | SK | Purpose |
+|--------|----|----|---------|
+| Patient | `PATIENT#{uid}` | `META_LATEST` | Patient master record |
+| MRN Pointer | `MRN#{mrn}` | `MRN` | MRN → UID lookup |
+| Timeline | `PATIENT#{uid}` | `TL#{timestamp}#{state}` | State transition log |
+| Note | `PATIENT#{uid}` | `NOTE#{timestamp}#{noteId}` | Clinical note |
+| Task | `PATIENT#{uid}` | `TASK#{taskId}` | Task record |
+| Medication | `PATIENT#{uid}` | `MED#{medId}` | Medication record |
+| Documents | `PATIENT#{uid}` | `DOCS#PROFILE` | Document registry |
+| Discharge | `PATIENT#{uid}` | `DS#{timestamp}#{dsId}` | Discharge version |
+| Discharge Latest | `PATIENT#{uid}` | `DS#LATEST` | Current discharge pointer |
+| Doctor | `USER#{doctorId}` | `PROFILE` | Doctor profile |
+| Checklist | `CHECKLIST` | `STAGE#{from}#TO#{to}` | State transition rules |
+
+### Indexes
+
+| Index | Type | PK | SK | Purpose |
+|-------|------|----|----|---------|
+| GSI1PK-index | GSI | GSI1PK | — | Patients by dept, doctors by dept |
+| GSI2PK-GSI2SK-index | GSI | GSI2PK | GSI2SK | Tasks dashboard (dept+status+assignee) |
+| LSI_CUR_MRN-index | LSI | PK | LSI_CUR_MRN | Patient by current MRN |
+
+### GSI Key Patterns
+
+| GSI1PK Pattern | Entity |
+|----------------|--------|
+| `DEPT#{dept}#ACTIVE` | Active patients in department |
+| `DEPT#{dept}#INACTIVE` | Inactive patients |
+| `DEPT#{dept}#ROLE#DOCTOR` | Doctors in department |
+
+| GSI2PK Pattern | GSI2SK Pattern | Entity |
+|----------------|----------------|--------|
+| `TASK#{STATUS}#DEPT#{dept}` | `ASSIGNEE#{id}#RECURRING#{YES/NO}#TASK#{taskId}` | Tasks |
+
+---
+
+## S3 File Organization
+
+```
+patients/{uid}/
+├── originals/          — Raw uploaded files
+├── optimized/
+│   ├── docs/{docType}/ — Clinical documents (preop, lab, radiology, etc.)
+│   ├── notes/{noteId}/ — Note attachments
+│   ├── meds/{medId}/   — Medication-related files
+│   └── tasks/{taskId}/ — Task-related files
+└── thumb/              — Thumbnails
+```
+
+Document types: `preop`, `lab`, `radiology`, `intraop`, `otnotes`, `postop`, `discharge`
+
+---
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AWS_REGION` | `ap-south-1` | AWS region |
+| `TABLE_NAME` | `HMS` | DynamoDB table name |
+| `FILES_BUCKET` | — | S3 bucket for patient files |
+| `PRESIGN_EXPIRES_SEC` | `900` | Presigned URL expiry (seconds) |
+| `CDN_DOMAIN` | — | CloudFront distribution domain |
+| `CF_DISTRIBUTION_ID` | — | CloudFront distribution ID |
+| `CDN_SIGNED` | `false` | Use signed CloudFront URLs |
+| `AWS_ENDPOINT` | — | Custom endpoint (for LocalStack) |
+
+---
+
+## Local Development
+
+See [local-backend-runbook.md](./local-backend-runbook.md) for running the backend locally with LocalStack.

--- a/Docs/backend/local-backend-runbook.md
+++ b/Docs/backend/local-backend-runbook.md
@@ -1,0 +1,316 @@
+# HMS Backend — Local Development Runbook
+
+Run the full HMS backend locally using **LocalStack** (DynamoDB + S3) and a lightweight Node.js HTTP server that wraps the Lambda handler.
+
+---
+
+## Prerequisites
+
+| Tool | Version | Install |
+|------|---------|---------|
+| Docker | 20+ | [docker.com](https://docs.docker.com/get-docker/) |
+| Node.js | 22+ | [nodejs.org](https://nodejs.org/) |
+| npm | 10+ | Comes with Node.js |
+
+Verify:
+```bash
+docker --version
+node --version
+npm --version
+```
+
+---
+
+## Quick Start (One Command)
+
+```bash
+cd backend/dev/local
+chmod +x start.sh
+./start.sh
+```
+
+This will:
+1. Start LocalStack via Docker Compose
+2. Wait for it to become healthy
+3. Install npm dependencies
+4. Create DynamoDB table with all indexes (GSIs + LSI)
+5. Create S3 bucket
+6. Seed sample patient and doctor data
+7. Start the local HTTP server on `http://localhost:3001`
+
+---
+
+## Step-by-Step Setup
+
+### 1. Start LocalStack
+
+```bash
+cd backend/dev/local
+docker compose up -d
+```
+
+Verify health:
+```bash
+curl http://localhost:4566/_localstack/health
+```
+
+### 2. Install Dependencies
+
+```bash
+npm install
+```
+
+### 3. Seed Database & S3
+
+```bash
+node seed.mjs
+```
+
+This creates:
+- DynamoDB table `HMS-LOCAL` with:
+  - Primary key: PK (String) + SK (String)
+  - LSI: LSI_CUR_MRN-index
+  - GSI: GSI1PK-index, GSI2PK-GSI2SK-index
+- S3 bucket `hms-patient-files-local`
+- Sample data:
+  - 2 patients (John Doe in Orthopedics, Jane Smith in Cardiology)
+  - 1 doctor (Dr. Local Dev)
+  - MRN pointers
+  - Timeline entries
+  - Checklist stage transitions
+
+### 4. Start the Server
+
+```bash
+node local-server.mjs
+```
+
+Server starts at `http://localhost:3001`.
+
+---
+
+## Connecting the Frontend
+
+Update the frontend Vite proxy to point to the local backend:
+
+**Option A: Environment variable**
+```bash
+# In the project root .env.local
+VITE_PROXY_TARGET=http://localhost:3001
+```
+
+**Option B: Direct in vite.config.ts** (not recommended for commit)
+```ts
+proxy: {
+  '/api': {
+    target: 'http://localhost:3001',
+    changeOrigin: true,
+    rewrite: (path) => path.replace(/^\/api/, ''),
+  },
+}
+```
+
+Then start the frontend:
+```bash
+npm run dev
+```
+
+---
+
+## NPM Scripts
+
+| Script | Command | Description |
+|--------|---------|-------------|
+| `npm start` | `node local-server.mjs` | Start the local server |
+| `npm run seed` | `node seed.mjs` | Create table/bucket and seed data |
+| `npm run setup` | `docker compose up -d && node seed.mjs` | Start LocalStack + seed |
+| `npm run teardown` | `docker compose down -v` | Stop LocalStack and delete data |
+| `npm run reset` | teardown + setup + seed | Full reset |
+
+---
+
+## How It Works
+
+### Architecture (Local)
+
+```
+┌─────────────┐     ┌────────────────────┐     ┌──────────────────┐
+│   Frontend   │────▶│  local-server.mjs  │────▶│  LocalStack      │
+│  :5173       │     │  :3001             │     │  :4566           │
+│              │     │                    │     │  ├── DynamoDB     │
+│              │     │  (HTTP → Lambda    │     │  └── S3           │
+│              │     │   event → handler) │     │                  │
+└─────────────┘     └────────────────────┘     └──────────────────┘
+```
+
+### Request Flow
+
+1. Frontend sends HTTP request to `http://localhost:3001/patients`
+2. `local-server.mjs` receives the request via Node.js `http.createServer`
+3. Server builds a Lambda Function URL-style event object:
+   - `rawPath`, `queryStringParameters`, `requestContext.http.method`, `body`
+4. Passes event to the imported `handler` from `router.mjs`
+5. Handler routes to the appropriate feature module
+6. Feature module queries LocalStack DynamoDB/S3
+7. Response flows back through the chain
+
+### AWS SDK Configuration
+
+The handler modules (`router.mjs`, `files.mjs`, `s3_events.mjs`) check the `AWS_ENDPOINT` environment variable:
+- **When set**: Creates AWS SDK clients with LocalStack endpoint + test credentials
+- **When unset**: Uses standard AWS SDK behavior (real AWS)
+
+This means the same handler code runs locally and in Lambda with zero branching.
+
+---
+
+## Verifying the Setup
+
+### Test Endpoints
+
+```bash
+# List patients
+curl -s http://localhost:3001/patients | jq .
+
+# Get specific patient
+curl -s http://localhost:3001/patients/01JLOCAL00001 | jq .
+
+# Get by MRN
+curl -s http://localhost:3001/patients/MRN-LOCAL-001 | jq .
+
+# List patients by department
+curl -s "http://localhost:3001/patients?department=Orthopedics" | jq .
+
+# Get timeline
+curl -s http://localhost:3001/patients/01JLOCAL00001/timeline | jq .
+
+# List doctors
+curl -s "http://localhost:3001/doctors?department=Orthopedics" | jq .
+
+# Create a new patient
+curl -s -X POST http://localhost:3001/patients \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Test Patient",
+    "registration": {
+      "mrn": "MRN-TEST-001",
+      "scheme": "GENERAL",
+      "department": "Orthopedics"
+    }
+  }' | jq .
+
+# Create a task
+curl -s -X POST http://localhost:3001/patients/01JLOCAL00001/tasks \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Check vitals",
+    "type": "assessment",
+    "due": "2026-03-26T10:00:00Z",
+    "assigneeId": "doc-local-001"
+  }' | jq .
+
+# List tasks
+curl -s http://localhost:3001/patients/01JLOCAL00001/tasks | jq .
+```
+
+### Inspect LocalStack Data
+
+```bash
+# List DynamoDB tables
+aws --endpoint-url=http://localhost:4566 dynamodb list-tables
+
+# Scan all items
+aws --endpoint-url=http://localhost:4566 dynamodb scan \
+  --table-name HMS-LOCAL --output json | jq '.Items | length'
+
+# List S3 buckets
+aws --endpoint-url=http://localhost:4566 s3 ls
+
+# List S3 objects
+aws --endpoint-url=http://localhost:4566 s3 ls s3://hms-patient-files-local/ --recursive
+```
+
+---
+
+## Troubleshooting
+
+### LocalStack won't start
+```bash
+# Check if port 4566 is in use
+lsof -i :4566
+
+# View logs
+docker compose logs localstack
+
+# Full reset
+docker compose down -v
+docker compose up -d
+```
+
+### "Table already exists" during seed
+This is safe — the seed script is idempotent.
+
+### "Connection refused" from local server
+Ensure LocalStack is running and healthy:
+```bash
+curl http://localhost:4566/_localstack/health
+```
+
+### S3 presigned URLs don't work from browser
+LocalStack presigned URLs use `localhost:4566` which is fine for server-side operations. For browser uploads, you may need to use the LocalStack URL directly or configure CORS on the LocalStack S3 bucket.
+
+### Frontend can't reach backend
+1. Verify the backend is running: `curl http://localhost:3001/patients`
+2. Check `VITE_PROXY_TARGET=http://localhost:3001` in root `.env.local`
+3. Restart the Vite dev server after changing env vars
+
+### Module import errors
+Ensure you're running from the `backend/dev/local` directory and dependencies are installed:
+```bash
+cd backend/dev/local
+npm install
+```
+
+---
+
+## Environment Variables
+
+All configuration is in `backend/dev/local/.env.local`:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AWS_ENDPOINT` | `http://localhost:4566` | LocalStack endpoint |
+| `AWS_REGION` | `ap-south-1` | AWS region |
+| `TABLE_NAME` | `HMS-LOCAL` | DynamoDB table name |
+| `FILES_BUCKET` | `hms-patient-files-local` | S3 bucket name |
+| `PRESIGN_EXPIRES_SEC` | `900` | Presigned URL TTL |
+| `PORT` | `3001` | Local server port |
+| `S3_FORCE_PATH_STYLE` | `true` | Required for LocalStack S3 |
+
+---
+
+## Differences from Production
+
+| Aspect | Local | Production |
+|--------|-------|------------|
+| Compute | Node.js HTTP server | AWS Lambda |
+| DynamoDB | LocalStack | AWS DynamoDB |
+| S3 | LocalStack | AWS S3 |
+| CDN | None | CloudFront |
+| Auth | None | None (Function URL, no auth) |
+| Region | ap-south-1 (simulated) | ap-south-1 |
+| Table | HMS-LOCAL | HMS-HYD |
+| Cold starts | None | Lambda cold starts |
+| Timeout | None | 30s |
+
+---
+
+## Cleaning Up
+
+```bash
+# Stop LocalStack (preserves data in Docker volume)
+docker compose stop
+
+# Stop and delete all data
+docker compose down -v
+```

--- a/backend/dev/HMSdevmrnchange/files.mjs
+++ b/backend/dev/HMSdevmrnchange/files.mjs
@@ -17,6 +17,7 @@ import { CloudFrontClient, CreateInvalidationCommand } from "@aws-sdk/client-clo
 /* ------------------------------ ENV & CLIENT ------------------------------ */
 
 const REGION = process.env.AWS_REGION || process.env.S3_REGION || "ap-south-1";
+const AWS_ENDPOINT = process.env.AWS_ENDPOINT || "";
 const BUCKET =
   process.env.FILES_BUCKET ||
   process.env.DOCS_BUCKET ||
@@ -26,7 +27,13 @@ const PRESIGN_EXPIRES_SEC = Number(
   process.env.PRESIGN_EXPIRES_SEC || process.env.S3_PRESIGN_EXPIRES || 900
 ); // 15min default
 
-const s3 = new S3Client({ region: REGION });
+const s3Opts = { region: REGION };
+if (AWS_ENDPOINT) {
+  s3Opts.endpoint = AWS_ENDPOINT;
+  s3Opts.forcePathStyle = true;
+  s3Opts.credentials = { accessKeyId: "test", secretAccessKey: "test" };
+}
+const s3 = new S3Client(s3Opts);
 const CF_DISTRIBUTION_ID = process.env.CF_DISTRIBUTION_ID || "";
 const CF_DOMAIN = process.env.CF_DOMAIN || process.env.CDN_DOMAIN || "";
 const cf = CF_DISTRIBUTION_ID ? new CloudFrontClient({ region: REGION }) : null;

--- a/backend/dev/HMSdevmrnchange/router.mjs
+++ b/backend/dev/HMSdevmrnchange/router.mjs
@@ -18,13 +18,20 @@ import { mountDischargeRoutes } from "./discharge.mjs";
 /* ---- env & clients ---- */
 const REGION = process.env.AWS_REGION || "ap-south-1";
 const TABLE = process.env.TABLE_NAME || "HMS";
+const AWS_ENDPOINT = process.env.AWS_ENDPOINT || "";
 
 // Patients/Doctors list GSIs
 const DEPT_INDEX = "GSI1PK-index";       // must project REG rows (patients) + doctors as you already do
 const TASK_GSI  = "GSI2PK-GSI2SK-index"; // existing tasks dashboard index
 
+const ddbClientOpts = { region: REGION };
+if (AWS_ENDPOINT) {
+  ddbClientOpts.endpoint = AWS_ENDPOINT;
+  ddbClientOpts.credentials = { accessKeyId: "test", secretAccessKey: "test" };
+}
+
 export const ddb = DynamoDBDocumentClient.from(
-  new DynamoDBClient({ region: REGION }),
+  new DynamoDBClient(ddbClientOpts),
   { marshallOptions: { removeUndefinedValues: true } }
 );
 

--- a/backend/dev/HMSdevmrnchange/s3_events.mjs
+++ b/backend/dev/HMSdevmrnchange/s3_events.mjs
@@ -13,12 +13,18 @@ import {
 } from "@aws-sdk/lib-dynamodb";
 
 const REGION = process.env.AWS_REGION || "ap-south-1";
+const AWS_ENDPOINT = process.env.AWS_ENDPOINT || "";
 const TABLE = process.env.TABLE_NAME || "HMS";
 const BUCKET = process.env.FILES_BUCKET || "";
 const CDN_DOMAIN = process.env.CDN_DOMAIN || "";
 
-const s3 = new S3Client({ region: REGION });
-const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({ region: REGION }));
+const clientOpts = { region: REGION };
+if (AWS_ENDPOINT) {
+  clientOpts.endpoint = AWS_ENDPOINT;
+  clientOpts.credentials = { accessKeyId: "test", secretAccessKey: "test" };
+}
+const s3 = new S3Client({ ...clientOpts, ...(AWS_ENDPOINT ? { forcePathStyle: true } : {}) });
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient(clientOpts));
 
 const DOC_SK = "DOCS#PROFILE";
 

--- a/backend/dev/local/docker-compose.yml
+++ b/backend/dev/local/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.8"
+
+services:
+  localstack:
+    image: localstack/localstack:latest
+    container_name: hms-localstack
+    ports:
+      - "4566:4566"       # LocalStack gateway
+      - "4510-4559:4510-4559"  # external service ports
+    environment:
+      - SERVICES=dynamodb,s3
+      - DEFAULT_REGION=ap-south-1
+      - EAGER_SERVICE_LOADING=1
+      - DEBUG=0
+    volumes:
+      - localstack_data:/var/lib/localstack
+      - /var/run/docker.sock:/var/run/docker.sock
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  localstack_data:

--- a/backend/dev/local/local-server.mjs
+++ b/backend/dev/local/local-server.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// local-server.mjs — HTTP server wrapping the Lambda handler for local development
+// Translates HTTP requests into Lambda Function URL event format
+// Usage: node local-server.mjs
+
+import { createServer } from "node:http";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ─── Load .env.local (must happen BEFORE importing handler) ─────────────────
+const envPath = resolve(__dirname, ".env.local");
+try {
+  const envContent = readFileSync(envPath, "utf-8");
+  for (const line of envContent.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eqIdx = trimmed.indexOf("=");
+    if (eqIdx === -1) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    const val = trimmed.slice(eqIdx + 1).trim();
+    if (!process.env[key]) process.env[key] = val;
+  }
+} catch {
+  console.warn("No .env.local found, using environment variables");
+}
+
+// ─── Import handler (env vars are set, so AWS_ENDPOINT is picked up) ────────
+const { handler } = await import("../HMSdevmrnchange/router.mjs");
+
+// ─── HTTP Server ────────────────────────────────────────────────────────────
+const PORT = Number(process.env.PORT) || 3001;
+const ENDPOINT = process.env.AWS_ENDPOINT || "http://localhost:4566";
+const TABLE = process.env.TABLE_NAME || "HMS-LOCAL";
+
+const server = createServer(async (req, res) => {
+  const startTime = Date.now();
+  let body = "";
+
+  req.on("data", (chunk) => { body += chunk; });
+  req.on("end", async () => {
+    const url = new URL(req.url, `http://localhost:${PORT}`);
+
+    // Build Lambda Function URL-style event
+    const event = {
+      version: "2.0",
+      rawPath: url.pathname,
+      rawQueryString: url.search.slice(1),
+      headers: { ...req.headers },
+      queryStringParameters: Object.fromEntries(url.searchParams),
+      requestContext: {
+        http: {
+          method: req.method,
+          path: url.pathname,
+          protocol: "HTTP/1.1",
+          sourceIp: "127.0.0.1",
+          userAgent: req.headers["user-agent"] || "",
+        },
+        time: new Date().toISOString(),
+        timeEpoch: Date.now(),
+      },
+      body: body || null,
+      isBase64Encoded: false,
+    };
+
+    try {
+      const result = await handler(event);
+      const elapsed = Date.now() - startTime;
+
+      // Log request with color
+      const status = result.statusCode || 200;
+      const color = status < 400 ? "\x1b[32m" : status < 500 ? "\x1b[33m" : "\x1b[31m";
+      console.log(`${color}${req.method}\x1b[0m ${url.pathname} → ${status} (${elapsed}ms)`);
+
+      // Write response
+      const headers = result.headers || {};
+      for (const [k, v] of Object.entries(headers)) {
+        res.setHeader(k, v);
+      }
+      res.writeHead(status);
+      res.end(result.body || "");
+    } catch (err) {
+      console.error("Server error:", err);
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Internal server error" }));
+    }
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`
+┌─────────────────────────────────────────────┐
+│  HMS Backend — Local Development Server     │
+├─────────────────────────────────────────────┤
+│  Server:     http://localhost:${PORT}           │
+│  LocalStack: ${ENDPOINT.padEnd(29)}│
+│  Table:      ${TABLE.padEnd(29)}│
+│  Region:     ${(process.env.AWS_REGION || "ap-south-1").padEnd(29)}│
+└─────────────────────────────────────────────┘
+`);
+});

--- a/backend/dev/local/package.json
+++ b/backend/dev/local/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "hms-backend-local",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Local development server for HMS backend using LocalStack",
+  "scripts": {
+    "start": "node local-server.mjs",
+    "seed": "node seed.mjs",
+    "setup": "docker compose up -d && node seed.mjs",
+    "teardown": "docker compose down -v",
+    "reset": "docker compose down -v && docker compose up -d && sleep 3 && node seed.mjs"
+  },
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.0.0",
+    "@aws-sdk/client-s3": "^3.0.0",
+    "@aws-sdk/client-cloudfront": "^3.0.0",
+    "@aws-sdk/lib-dynamodb": "^3.0.0",
+    "@aws-sdk/s3-request-presigner": "^3.0.0"
+  }
+}

--- a/backend/dev/local/seed.mjs
+++ b/backend/dev/local/seed.mjs
@@ -1,0 +1,293 @@
+#!/usr/bin/env node
+// seed.mjs — Create DynamoDB table + S3 bucket in LocalStack, then seed sample data
+// Usage: node seed.mjs
+
+import {
+  DynamoDBClient,
+  CreateTableCommand,
+  DescribeTableCommand,
+} from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  S3Client,
+  CreateBucketCommand,
+  HeadBucketCommand,
+} from "@aws-sdk/client-s3";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Load .env.local
+const envPath = resolve(__dirname, ".env.local");
+try {
+  const envContent = readFileSync(envPath, "utf-8");
+  for (const line of envContent.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eqIdx = trimmed.indexOf("=");
+    if (eqIdx === -1) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    const val = trimmed.slice(eqIdx + 1).trim();
+    if (!process.env[key]) process.env[key] = val;
+  }
+} catch {
+  console.warn("No .env.local found, using environment variables");
+}
+
+const ENDPOINT = process.env.AWS_ENDPOINT || "http://localhost:4566";
+const REGION = process.env.AWS_REGION || "ap-south-1";
+const TABLE = process.env.TABLE_NAME || "HMS-LOCAL";
+const BUCKET = process.env.FILES_BUCKET || "hms-patient-files-local";
+
+const clientConfig = {
+  region: REGION,
+  endpoint: ENDPOINT,
+  credentials: { accessKeyId: "test", secretAccessKey: "test" },
+};
+
+const dynamoRaw = new DynamoDBClient(clientConfig);
+const ddb = DynamoDBDocumentClient.from(dynamoRaw, {
+  marshallOptions: { removeUndefinedValues: true },
+});
+const s3 = new S3Client({ ...clientConfig, forcePathStyle: true });
+
+// ─── Create DynamoDB Table ───────────────────────────────────────────────────
+async function createTable() {
+  try {
+    await dynamoRaw.send(new DescribeTableCommand({ TableName: TABLE }));
+    console.log(`✓ Table "${TABLE}" already exists`);
+    return;
+  } catch (e) {
+    if (e.name !== "ResourceNotFoundException") throw e;
+  }
+
+  console.log(`Creating table "${TABLE}"...`);
+  await dynamoRaw.send(
+    new CreateTableCommand({
+      TableName: TABLE,
+      BillingMode: "PAY_PER_REQUEST",
+      AttributeDefinitions: [
+        { AttributeName: "PK", AttributeType: "S" },
+        { AttributeName: "SK", AttributeType: "S" },
+        { AttributeName: "GSI1PK", AttributeType: "S" },
+        { AttributeName: "GSI2PK", AttributeType: "S" },
+        { AttributeName: "GSI2SK", AttributeType: "S" },
+        { AttributeName: "LSI_CUR_MRN", AttributeType: "S" },
+      ],
+      KeySchema: [
+        { AttributeName: "PK", KeyType: "HASH" },
+        { AttributeName: "SK", KeyType: "RANGE" },
+      ],
+      LocalSecondaryIndexes: [
+        {
+          IndexName: "LSI_CUR_MRN-index",
+          KeySchema: [
+            { AttributeName: "PK", KeyType: "HASH" },
+            { AttributeName: "LSI_CUR_MRN", KeyType: "RANGE" },
+          ],
+          Projection: { ProjectionType: "ALL" },
+        },
+      ],
+      GlobalSecondaryIndexes: [
+        {
+          IndexName: "GSI1PK-index",
+          KeySchema: [{ AttributeName: "GSI1PK", KeyType: "HASH" }],
+          Projection: { ProjectionType: "ALL" },
+        },
+        {
+          IndexName: "GSI2PK-GSI2SK-index",
+          KeySchema: [
+            { AttributeName: "GSI2PK", KeyType: "HASH" },
+            { AttributeName: "GSI2SK", KeyType: "RANGE" },
+          ],
+          Projection: { ProjectionType: "ALL" },
+        },
+      ],
+    })
+  );
+  console.log(`✓ Table "${TABLE}" created`);
+}
+
+// ─── Create S3 Bucket ────────────────────────────────────────────────────────
+async function createBucket() {
+  try {
+    await s3.send(new HeadBucketCommand({ Bucket: BUCKET }));
+    console.log(`✓ Bucket "${BUCKET}" already exists`);
+    return;
+  } catch (e) {
+    if (e.name !== "NotFound" && e.$metadata?.httpStatusCode !== 404) throw e;
+  }
+
+  console.log(`Creating bucket "${BUCKET}"...`);
+  await s3.send(
+    new CreateBucketCommand({
+      Bucket: BUCKET,
+      CreateBucketConfiguration: { LocationConstraint: REGION },
+    })
+  );
+  console.log(`✓ Bucket "${BUCKET}" created`);
+}
+
+// ─── Seed Sample Data ────────────────────────────────────────────────────────
+async function seedData() {
+  const now = new Date().toISOString();
+  const uid1 = "01JLOCAL00001";
+  const uid2 = "01JLOCAL00002";
+
+  const items = [
+    // Patient 1
+    {
+      PK: `PATIENT#${uid1}`,
+      SK: "META_LATEST",
+      patient_uid: uid1,
+      name: "John Doe (Local)",
+      age: 45,
+      sex: "M",
+      department: "Orthopedics",
+      status: "ACTIVE",
+      pathway: "elective",
+      current_state: "admitted",
+      diagnosis: "Knee replacement",
+      comorbidities: ["Diabetes"],
+      active_reg_mrn: "MRN-LOCAL-001",
+      active_scheme: "GENERAL",
+      mrn_history: [{ mrn: "MRN-LOCAL-001", scheme: "GENERAL", date: now }],
+      LSI_CUR_MRN: "CUR#MRN-LOCAL-001",
+      GSI1PK: "DEPT#Orthopedics#ACTIVE",
+      state_dates: { admitted: now },
+      timeline_open_sk: `TL#${now}#admitted`,
+      update_counter: 0,
+      created_at: now,
+      updated_at: now,
+      last_updated: now,
+    },
+    // MRN pointer for Patient 1
+    {
+      PK: "MRN#MRN-LOCAL-001",
+      SK: "MRN",
+      mrn: "MRN-LOCAL-001",
+      patient_uid: uid1,
+      scheme: "GENERAL",
+      department: "Orthopedics",
+      status: "ACTIVE",
+      created_at: now,
+      updated_at: now,
+    },
+    // Timeline for Patient 1
+    {
+      PK: `PATIENT#${uid1}`,
+      SK: `TL#${now}#admitted`,
+      timeline_id: `tl-${Date.now()}`,
+      patient_uid: uid1,
+      mrn: "MRN-LOCAL-001",
+      scheme: "GENERAL",
+      state: "admitted",
+      date_in: now,
+      date_out: null,
+      checklist_in_done: [],
+      checklist_out_done: [],
+      required_in: [],
+      required_out: [],
+      created_at: now,
+      updated_at: now,
+    },
+    // Patient 2
+    {
+      PK: `PATIENT#${uid2}`,
+      SK: "META_LATEST",
+      patient_uid: uid2,
+      name: "Jane Smith (Local)",
+      age: 32,
+      sex: "F",
+      department: "Cardiology",
+      status: "ACTIVE",
+      pathway: "emergency",
+      current_state: "pre-op",
+      diagnosis: "Valve repair",
+      comorbidities: [],
+      active_reg_mrn: "MRN-LOCAL-002",
+      active_scheme: "INSURANCE",
+      mrn_history: [{ mrn: "MRN-LOCAL-002", scheme: "INSURANCE", date: now }],
+      LSI_CUR_MRN: "CUR#MRN-LOCAL-002",
+      GSI1PK: "DEPT#Cardiology#ACTIVE",
+      state_dates: { admitted: now, "pre-op": now },
+      timeline_open_sk: `TL#${now}#pre-op`,
+      update_counter: 0,
+      created_at: now,
+      updated_at: now,
+      last_updated: now,
+    },
+    // MRN pointer for Patient 2
+    {
+      PK: "MRN#MRN-LOCAL-002",
+      SK: "MRN",
+      mrn: "MRN-LOCAL-002",
+      patient_uid: uid2,
+      scheme: "INSURANCE",
+      department: "Cardiology",
+      status: "ACTIVE",
+      created_at: now,
+      updated_at: now,
+    },
+    // Doctor
+    {
+      PK: "USER#doc-local-001",
+      SK: "PROFILE",
+      user_id: "doc-local-001",
+      name: "Dr. Local Dev",
+      role: "doctor",
+      department: "Orthopedics",
+      email: "doctor@local.dev",
+      avatar: null,
+      contact_info: {},
+      permissions: [],
+      GSI1PK: "DEPT#Orthopedics#ROLE#DOCTOR",
+      created_at: now,
+      updated_at: now,
+      deleted: false,
+    },
+    // Checklist stage example
+    {
+      PK: "CHECKLIST",
+      SK: "STAGE#admitted#TO#pre-op",
+      in_required: ["vitals", "consent"],
+      out_required: ["blood-work"],
+      created_at: now,
+    },
+    {
+      PK: "CHECKLIST",
+      SK: "STAGE#pre-op#TO#intra-op",
+      in_required: ["anesthesia-clearance"],
+      out_required: ["ot-prep"],
+      created_at: now,
+    },
+  ];
+
+  console.log(`Seeding ${items.length} items...`);
+  for (const item of items) {
+    await ddb.send(new PutCommand({ TableName: TABLE, Item: item }));
+  }
+  console.log(`✓ Seeded ${items.length} items`);
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+async function main() {
+  console.log(`\n🏥 HMS Local Setup`);
+  console.log(`  Endpoint: ${ENDPOINT}`);
+  console.log(`  Region:   ${REGION}`);
+  console.log(`  Table:    ${TABLE}`);
+  console.log(`  Bucket:   ${BUCKET}\n`);
+
+  await createTable();
+  await createBucket();
+  await seedData();
+
+  console.log(`\n✓ Local environment ready!\n`);
+}
+
+main().catch((err) => {
+  console.error("Setup failed:", err);
+  process.exit(1);
+});

--- a/backend/dev/local/start.sh
+++ b/backend/dev/local/start.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# start.sh — One-command local backend setup
+# Usage: ./start.sh [--reset]
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${GREEN}HMS Backend — Local Setup${NC}"
+echo "================================"
+
+# Check prerequisites
+command -v docker >/dev/null 2>&1 || { echo -e "${RED}docker is required but not installed.${NC}"; exit 1; }
+command -v node >/dev/null 2>&1 || { echo -e "${RED}node is required but not installed.${NC}"; exit 1; }
+
+# Reset if requested
+if [[ "${1:-}" == "--reset" ]]; then
+  echo -e "${YELLOW}Resetting LocalStack...${NC}"
+  docker compose down -v 2>/dev/null || true
+fi
+
+# Start LocalStack
+echo "Starting LocalStack..."
+docker compose up -d
+
+# Wait for LocalStack to be healthy
+echo "Waiting for LocalStack to be ready..."
+for i in $(seq 1 30); do
+  if curl -sf http://localhost:4566/_localstack/health >/dev/null 2>&1; then
+    echo -e "${GREEN}LocalStack is ready${NC}"
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    echo -e "${RED}LocalStack failed to start${NC}"
+    exit 1
+  fi
+  sleep 1
+done
+
+# Install dependencies if needed
+if [ ! -d "node_modules" ]; then
+  echo "Installing dependencies..."
+  npm install
+fi
+
+# Seed data
+echo "Seeding database and S3..."
+node seed.mjs
+
+# Start server
+echo ""
+echo -e "${GREEN}Starting local server...${NC}"
+node local-server.mjs


### PR DESCRIPTION
## Summary

- Add `AWS_ENDPOINT` env var support to `router.mjs`, `files.mjs`, and `s3_events.mjs` so AWS SDK clients connect to LocalStack when set (no-op in production)
- Add `backend/dev/local/` directory with complete local development tooling:
  - `docker-compose.yml` — LocalStack container (DynamoDB + S3)
  - `local-server.mjs` — Node.js HTTP server wrapping the Lambda handler
  - `seed.mjs` — Creates DynamoDB table (with all GSIs/LSI), S3 bucket, and sample data
  - `start.sh` — One-command setup script
  - `.env.local` — Local environment configuration
  - `package.json` — Local dev dependencies and npm scripts
- Add comprehensive documentation:
  - `Docs/backend/backend-architecture.md` — Full backend architecture reference (endpoints, DynamoDB schema, S3 layout)
  - `Docs/backend/local-backend-runbook.md` — Step-by-step local dev runbook with troubleshooting

## Test plan

- [ ] Run `cd backend/dev/local && ./start.sh` — verify LocalStack starts and seeds
- [ ] `curl http://localhost:3001/patients` — verify patient list returns seeded data
- [ ] `curl http://localhost:3001/patients/01JLOCAL00001` — verify single patient fetch
- [ ] `curl "http://localhost:3001/doctors?department=Orthopedics"` — verify doctor listing
- [ ] Test POST/PATCH/DELETE operations against local server
- [ ] Verify production deployment is unaffected (AWS_ENDPOINT unset = standard behavior)
- [ ] Connect frontend with `VITE_PROXY_TARGET=http://localhost:3001` and verify UI works

https://claude.ai/code/session_01YbhU6epfrU8iaSWNLtZDBS